### PR TITLE
Add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+## [0.18.0] - 2018-09-10
+### Added
+- ReplayGain feature. This is still considered experimental at this point.
+Thanks to [@knacky34](https://github.com/knacky34)!
+- Add a transparent widget.
+- Preference to turn off shuffle mode when selecting new list of songs.
+- Select all items in a list.
+- Export multiple playlists at once.
+
+### Changed
+- Show unknown year consistently everywhere.
+- Also look for png album covers in the folder.
+- Show "-" instead of "0" when the album year is not available.
+- Show "Unknown Artist" when the artist name is unknown.
+- Navigation bar button colors for light themes.
+
+### Fixed
+- Crash with custom artist images.
+- App intro crash.
+- Crash for some artist names which contain special characters.
+- Loading of very large embedded album art.
+- Broken layout for super long artist names.
+
+## [0.17.0] - 2018-05-01
+### Added
+- Album redesign thanks to Adrian (that's not me! :-)).
+- New "Scan" option thanks to [@kabouzeid](https://github.com/kabouzeid).
+- Sorting feature thanks to [@soren121](https://github.com/soren21).
+
+## [0.16.5.2] - 2018-04-28
+### Changed
+- Upgrade to Glide 4.
+
+## [0.16.4.4] - 2018-01-18
+### Changed
+- Hide the tab bar when only one tab is activated.
+
+## 0.16.4.3 - 2018-01-02
+### Added
+- Initial version.
+
+[Unreleased]: https://github.com/AdrienPoupa/VinylMusicPlayer/compare/0.18.0...HEAD
+[0.18.0]: https://github.com/AdrienPoupa/VinylMusicPlayer/compare/0.17.0...0.18.0
+[0.17.0]: https://github.com/AdrienPoupa/VinylMusicPlayer/compare/0.16.5.2...0.17.0
+[0.16.5.2]: https://github.com/AdrienPoupa/VinylMusicPlayer/compare/0.16.4.4...0.16.5.2
+[0.16.4.4]: https://github.com/AdrienPoupa/VinylMusicPlayer/compare/0.16.4.3...0.16.4.4


### PR DESCRIPTION
Having a CHANGELOG.md has several benefits:

- it's a standard file that is easily discoverable by developers and advanced users.
- it's based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) specs.
- it can be leveraged to generate other documents, such as:
  - the HTML changelog that end users can see when they launch an updated version of Vinyl Music Player (e.g. on Linux using pandoc: `$ tail -n +9 CHANGELOG.md | pandoc -f commonmark -s -o changelog.html`).
  - a text file per version as used in fastlane or [F-Droid metadata repository](https://f-droid.org/en/docs/All_About_Descriptions_Graphics_and_Screenshots/#in-the-apps-build-metadata-in-an-fdroiddata-collection).