### PR TITLE
Begin to work on Android Auto pagination

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -92,6 +92,7 @@ dependencies {
     implementation 'org.eclipse.mylyn.github:org.eclipse.egit.github.core:2.1.5'
     implementation 'com.jakewharton:butterknife:8.8.1'
     implementation 'com.github.AdrienPoupa:jaudiotagger:2.2.3'
+    implementation "android.arch.paging:runtime:1.0.1"
     implementation('com.h6ah4i.android.widget.advrecyclerview:advrecyclerview:0.11.0@aar') {
         transitive = true
     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/auto/AutoMusicProvider.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/auto/AutoMusicProvider.java
@@ -2,9 +2,11 @@ package com.poupa.vinylmusicplayer.auto;
 
 import android.content.Context;
 import android.content.res.Resources;
+import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.AsyncTask;
+import android.provider.MediaStore;
 import android.support.annotation.Nullable;
 import android.support.v4.media.MediaBrowserCompat;
 import android.support.v4.media.MediaDescriptionCompat;

--- a/app/src/main/java/com/poupa/vinylmusicplayer/auto/CursorBasedMediaProvider.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/auto/CursorBasedMediaProvider.java
@@ -1,0 +1,48 @@
+package com.poupa.vinylmusicplayer.auto;
+
+import android.content.Context;
+import android.database.Cursor;
+import android.database.DatabaseUtils;
+import android.net.Uri;
+import android.provider.MediaStore;
+import android.support.annotation.Nullable;
+import android.support.v4.content.ContentResolverCompat;
+
+import com.poupa.vinylmusicplayer.loader.SongLoader;
+import com.poupa.vinylmusicplayer.model.Song;
+import com.poupa.vinylmusicplayer.util.PreferenceUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CursorBasedMediaProvider {
+
+    private Cursor cursor;
+
+    CursorBasedMediaProvider(Context applicationContext) {
+        cursor = SongLoader.makeSongCursor(applicationContext, null, null, PreferenceUtil.getInstance().getSongSortOrder());
+    }
+
+    public int getMediaSize() {
+        return cursor.getCount();
+    }
+
+    public Song getSongAtPosition(int position) {
+        //DatabaseUtils.dumpCursorToString(cursor);
+        if (!cursor.moveToPosition(position))
+            return null;
+
+        return SongLoader.getSongFromCursorImpl(cursor);
+    }
+
+    public List<Song> getSongsAtRange(int startPosition, int endPosition) {
+        List<Song> songs = new ArrayList<>();
+        for (int position = startPosition; position < endPosition; ++position) {
+            Song song = getSongAtPosition(position);
+            if (song != null)
+                songs.add(song);
+        }
+
+        return songs;
+    }
+}

--- a/app/src/main/java/com/poupa/vinylmusicplayer/loader/SongLoader.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/loader/SongLoader.java
@@ -1,5 +1,8 @@
 package com.poupa.vinylmusicplayer.loader;
 
+import android.arch.lifecycle.LiveData;
+import android.arch.paging.LivePagedListBuilder;
+import android.arch.paging.PagedList;
 import android.content.Context;
 import android.database.Cursor;
 import android.provider.BaseColumns;
@@ -7,6 +10,7 @@ import android.provider.MediaStore;
 import android.provider.MediaStore.Audio.AudioColumns;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.v4.media.MediaBrowserCompat;
 
 import com.poupa.vinylmusicplayer.model.Song;
 import com.poupa.vinylmusicplayer.provider.BlacklistStore;
@@ -46,6 +50,14 @@ public class SongLoader {
         return getSongs(cursor);
     }
 
+    public static LiveData<PagedList<Song>> getSongs(MediaBrowserCompat mediaBrowser) {
+        PagedList.Config config = new PagedList.Config.Builder()
+                .setEnablePlaceholders(false)
+                .setPageSize(10)
+                .build();
+        return new LivePagedListBuilder<>(new SongsDataSourceFactory(mediaBrowser), config).build();
+    }
+
     @NonNull
     public static Song getSong(@NonNull final Context context, final int queryId) {
         Cursor cursor = makeSongCursor(context, AudioColumns._ID + "=?", new String[]{String.valueOf(queryId)});
@@ -81,7 +93,7 @@ public class SongLoader {
     }
 
     @NonNull
-    private static Song getSongFromCursorImpl(@NonNull Cursor cursor) {
+    public static Song getSongFromCursorImpl(@NonNull Cursor cursor) {
         final int id = cursor.getInt(0);
         final String title = cursor.getString(1);
         final int trackNumber = cursor.getInt(2);

--- a/app/src/main/java/com/poupa/vinylmusicplayer/loader/SongsDataSource.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/loader/SongsDataSource.java
@@ -1,0 +1,101 @@
+package com.poupa.vinylmusicplayer.loader;
+
+import android.arch.paging.PositionalDataSource;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v4.media.MediaBrowserCompat;
+import android.support.v4.media.MediaBrowserServiceCompat;
+
+import com.poupa.vinylmusicplayer.auto.AutoMediaIDHelper;
+import com.poupa.vinylmusicplayer.model.Song;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class SongsDataSource extends PositionalDataSource<Song> {
+
+    private final MediaBrowserCompat mediaBrowser;
+    private String rootId;
+    private Set<Integer> loadedPages = new HashSet<>();
+
+    SongsDataSource(MediaBrowserCompat mediaBrowser) {
+        this.mediaBrowser = mediaBrowser;
+    }
+
+    @Override
+    public void loadInitial(@NonNull final LoadInitialParams params, @NonNull final LoadInitialCallback<Song> callback) {
+        String parentId = getParentId(params.requestedStartPosition);
+        Bundle extra = getInitialPageBundle(params);
+        mediaBrowser.subscribe(parentId, extra, new MediaBrowserCompat.SubscriptionCallback() {
+            @Override
+            public void onChildrenLoaded(@NonNull String parentId, @NonNull List<MediaBrowserCompat.MediaItem> children, @NonNull Bundle options) {
+                loadedPages.add(0);
+                List<Song> songs = MapToSongs(children);
+                callback.onResult(songs, params.requestedStartPosition);
+            }
+        });
+    }
+
+    @Override
+    public void loadRange(@NonNull final LoadRangeParams params, @NonNull final LoadRangeCallback<Song> callback) {
+        final int pageIndex = getPageIndex(params);
+        if (loadedPages.contains(pageIndex)) {
+            callback.onResult(new ArrayList<>());
+            return;
+        }
+
+        String parentId = getParentId(params.startPosition);
+        Bundle extra = getRangeBundle(params);
+        mediaBrowser.subscribe(parentId, extra, new MediaBrowserCompat.SubscriptionCallback() {
+            @Override
+            public void onChildrenLoaded(@NonNull String parentId, @NonNull List<MediaBrowserCompat.MediaItem> children, @NonNull Bundle options) {
+                loadedPages.add(pageIndex);
+                List<Song> songs = MapToSongs(children);
+                callback.onResult(songs);
+            }
+        });
+    }
+
+    private int getPageIndex(LoadRangeParams params) {
+        return params.startPosition / params.loadSize;
+    }
+
+    private Bundle getRangeBundle(LoadRangeParams params) {
+        Bundle extra = new Bundle();
+        extra.putInt(MediaBrowserCompat.EXTRA_PAGE, getPageIndex(params));
+        extra.putInt(MediaBrowserCompat.EXTRA_PAGE_SIZE, params.loadSize);
+        return extra;
+    }
+
+    @NonNull
+    private Bundle getInitialPageBundle(@NonNull LoadInitialParams params) {
+        Bundle extra = new Bundle();
+        extra.putInt(MediaBrowserCompat.EXTRA_PAGE, 0);
+        extra.putInt(MediaBrowserCompat.EXTRA_PAGE_SIZE, params.pageSize);
+        return extra;
+    }
+
+    private List<Song> MapToSongs(List<MediaBrowserCompat.MediaItem> children) {
+        List<Song> songs = new ArrayList<>();
+        for (MediaBrowserCompat.MediaItem mediaItem : children) {
+            Bundle songBundle = mediaItem.getDescription().getExtras();
+            Song song = new Song((int) songBundle.get("id"), (String) songBundle.get("title"), (int) songBundle.get("trackNumber"),
+                    (int) songBundle.get("year"), (long) songBundle.get("duration"), (String) songBundle.get("data"),
+                    (long) songBundle.get("dateAdded"), (long) songBundle.get("dateModified"), (int) songBundle.get("albumId"),
+                    (String) songBundle.get("albumName"), (int) songBundle.get("artistId"), (String) songBundle.get("artistName"));
+            songs.add(song);
+        }
+
+        return songs;
+    }
+
+    private String getParentId(int requestedStartPosition) {
+        if (rootId == null)
+            //rootId = mediaBrowser.getRoot();
+            rootId = new MediaBrowserServiceCompat.BrowserRoot(AutoMediaIDHelper.MEDIA_ID_ROOT, null).getRootId();
+
+        return rootId + requestedStartPosition;
+    }
+}

--- a/app/src/main/java/com/poupa/vinylmusicplayer/loader/SongsDataSourceFactory.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/loader/SongsDataSourceFactory.java
@@ -1,0 +1,20 @@
+package com.poupa.vinylmusicplayer.loader;
+
+import android.arch.paging.DataSource;
+import android.support.v4.media.MediaBrowserCompat;
+
+import com.poupa.vinylmusicplayer.model.Song;
+
+public class SongsDataSourceFactory extends DataSource.Factory<Integer, Song> {
+
+    private final MediaBrowserCompat mediaBrowser;
+
+    SongsDataSourceFactory(MediaBrowserCompat mediaBrowser) {
+        this.mediaBrowser = mediaBrowser;
+    }
+
+    @Override
+    public DataSource<Integer, Song> create() {
+        return new SongsDataSource(mediaBrowser);
+    }
+}

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/library/pager/SongsFragment.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/library/pager/SongsFragment.java
@@ -1,15 +1,26 @@
 package com.poupa.vinylmusicplayer.ui.fragments.mainactivity.library.pager;
 
+import android.content.ComponentName;
 import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.os.Bundle;
+import android.os.RemoteException;
+import android.service.media.MediaBrowserService;
 import android.support.annotation.NonNull;
 import android.support.v4.app.LoaderManager;
 import android.support.v4.content.Loader;
+import android.support.v4.media.MediaBrowserCompat;
+import android.support.v4.media.session.MediaControllerCompat;
+import android.support.v4.media.session.MediaSessionCompat;
 import android.support.v7.widget.GridLayoutManager;
 
+import com.poupa.vinylmusicplayer.BuildConfig;
 import com.poupa.vinylmusicplayer.R;
 import com.poupa.vinylmusicplayer.adapter.song.ShuffleButtonSongAdapter;
 import com.poupa.vinylmusicplayer.adapter.song.SongAdapter;
+import com.poupa.vinylmusicplayer.auto.AutoMusicBrowserService;
 import com.poupa.vinylmusicplayer.interfaces.LoaderIds;
 import com.poupa.vinylmusicplayer.loader.SongLoader;
 import com.poupa.vinylmusicplayer.misc.WrappedAsyncTaskLoader;
@@ -17,6 +28,7 @@ import com.poupa.vinylmusicplayer.model.Song;
 import com.poupa.vinylmusicplayer.util.PreferenceUtil;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Karim Abou Zeid (kabouzeid)
@@ -25,10 +37,86 @@ public class SongsFragment extends AbsLibraryPagerRecyclerViewCustomGridSizeFrag
 
     private static final int LOADER_ID = LoaderIds.SONGS_FRAGMENT;
 
+    private MediaBrowserCompat mMediaBrowser;
+
+    private MediaBrowserCompat.ConnectionCallback mConnectionCallbacks = new MediaBrowserCompat.ConnectionCallback() {
+        @Override
+        public void onConnected() {
+            try {
+                // Ah, here’s our Token again
+                MediaSessionCompat.Token token =
+                        mMediaBrowser.getSessionToken();
+                // This is what gives us access to everything
+                MediaControllerCompat controller =
+                        new MediaControllerCompat(getContext(), token);
+
+                // Convenience method to allow you to use
+                // MediaControllerCompat.getMediaController() anywhere
+                MediaControllerCompat.setMediaController(
+                        getActivity(), controller);
+
+                /*SongLoader.getSongs(mMediaBrowser).observe(getActivity(), songs -> {
+                    //adapter.submitList(songs);
+                    getAdapter().notifyDataSetChanged();
+                });*/
+            } catch (RemoteException e) {
+                e.printStackTrace();
+                int i = 0;
+            }
+        }
+
+        @Override
+        public void onConnectionSuspended() {
+            // We were connected, but no longer :-(
+            int i = 0;
+        }
+
+        @Override
+        public void onConnectionFailed() {
+            // The attempt to connect failed completely.
+            // Check the ComponentName!
+            int i = 0;
+        }
+    };
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        // The usual setContentView, etc
+        // Now create the MediaBrowserCompat
+        /*mMediaBrowser = new MediaBrowserCompat(
+                getContext(), // a Context
+                new ComponentName(getActivity(), AutoMusicBrowserService.class),
+                // Which MediaBrowserService
+                ,
+                null); // optional Bundle
+        mMediaBrowser.connect();
+
+        mMediaBrowser = new MediaBrowserCompat(getContext(),
+                new ComponentName(BuildConfig.APPLICATION_ID,
+                        AutoMusicBrowserService.class.getName()), mConnectionCallbacks, null);
+        */
+        mMediaBrowser = new MediaBrowserCompat(getContext(),
+                new ComponentName(BuildConfig.APPLICATION_ID,
+                        AutoMusicBrowserService.class.getName()), mConnectionCallbacks, null);
+        mMediaBrowser.connect();
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        mMediaBrowser.disconnect();
+    }
+
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
         getLoaderManager().initLoader(LOADER_ID, null, this);
+        SongLoader.getSongs(mMediaBrowser).observe(this, songs -> {
+            //adapter.submitList(songs);
+            getAdapter().notifyDataSetChanged();
+        });
     }
 
     @NonNull
@@ -129,6 +217,11 @@ public class SongsFragment extends AbsLibraryPagerRecyclerViewCustomGridSizeFrag
 
     @Override
     public Loader<ArrayList<Song>> onCreateLoader(int id, Bundle args) {
+        /*SongLoader.getSongs(mMediaBrowser).observe(this, songs -> {
+            //adapter.submitList(songs);
+            getAdapter().notifyDataSetChanged();
+        });*/
+
         return new AsyncSongLoader(getActivity());
     }
 


### PR DESCRIPTION
This PR aims to bring pagination to Android Auto using this [blog post](https://medium.com/sears-israel/how-to-paginate-mediabrowserservice-e4fdc902ff2).

It is not working as expected so far, because, as mentioned by @theduffmaster [here](https://github.com/kabouzeid/Phonograph/issues/182#issuecomment-314444856), it is difficult to get the `MediaBrowserCompat` instance used by Android Auto.

I tried to do so using the best answer from this [Stackoverflow post](https://stackoverflow.com/questions/45027916/how-to-set-extra-page-and-extra-page-size-in-a-mediabrowserservicecompat-by-gett):

```
mMediaBrowser = new MediaBrowserCompat(getContext(),
                new ComponentName(BuildConfig.APPLICATION_ID,
                        AutoMusicBrowserService.class.getName()), mConnectionCallbacks, null);
```

However, I'm not sure it actually gets Auto's instance and does not create a new one.

About the code I wrote, interestingly, two behaviors can be observed: when I connect to the MediaBrowserCompat instance manually, that is, by doing `mMediaBrowser.connect();` in the UI, everything is working as expected, ie I can go until the call to
`public void onLoadChildren(@NonNull final String parentId, @NonNull final Result<List<MediaBrowserCompat.MediaItem>> result, @NonNull Bundle options) {`
in `AutoMusicBrowserService` and successfully get the first 10 songs from the DB as `MediaItems`.
This happens when the application displays the `SongsFragment` where the connect code is.

Now, when I launch Android Auto, the code in `SongsFragment`is also run and I can go as far as the call to `loadInitial` in the `SongsDataSource` BUT the function called in `AutoMusicBrowserService` is 
`public void onLoadChildren(@NonNull String parentId, @NonNull Result<List<MediaBrowserCompat.MediaItem>> result) {`
and not the one with the bundles that would contain the pagination parameters. Thus, the Bundles are not sent so there must be something wrong with `loadInitial`.

I suspect one of the following:
* We do not actually get the right `MediaBrowserCompat` instance from Android Auto
* A thread issue occurs so that the loadInitial call is performed after the call to onLoadChildren is done
* Something else?

I would really appreciate your help. I'll try to debug it some more tomorrow but I spent almost a full day to reach this result and I'm not sure what to do next.

Thanks :)

@arkon @paolovalerdi @Beesham