### PR TITLE
changelog: fix date typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-## [0.20.2] - 2019-01-25
+## [0.20.2] - 2019-02-25
 ### Fixed
 - Titles not showing for Android 6 and below
 
-## [0.20.1] - 2019-01-22
+## [0.20.1] - 2019-02-22
 ### Fixed
 - Bump database version
 


### PR DESCRIPTION
I noticed the version numbers increased, but the dates went back in time ;)