### PR TITLE
Skipped songs

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
@@ -59,6 +59,7 @@ import com.poupa.vinylmusicplayer.service.notification.PlayingNotificationImpl24
 import com.poupa.vinylmusicplayer.service.playback.Playback;
 import com.poupa.vinylmusicplayer.util.MusicUtil;
 import com.poupa.vinylmusicplayer.util.PackageValidator;
+import com.poupa.vinylmusicplayer.util.PlaylistsUtil;
 import com.poupa.vinylmusicplayer.util.PreferenceUtil;
 import com.poupa.vinylmusicplayer.util.Util;
 
@@ -448,6 +449,14 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
     }
 
     public void playNextSong(boolean force) {
+        if (PreferenceUtil.getInstance().maintainSkippedSongsPlaylist()) {
+            PlaylistsUtil.addToPlaylist(
+                    this,
+                    getCurrentSong(),
+                    MusicUtil.getOrCreateSkippedPlaylist(this).id,
+                    true);
+        }
+
         playSongAt(getNextPosition(force));
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
@@ -449,12 +449,9 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
     }
 
     public void playNextSong(boolean force) {
-        if (PreferenceUtil.getInstance().maintainSkippedSongsPlaylist()) {
-            PlaylistsUtil.addToPlaylist(
-                    this,
-                    getCurrentSong(),
-                    MusicUtil.getOrCreateSkippedPlaylist(this).id,
-                    true);
+        if (force && PreferenceUtil.getInstance().maintainSkippedSongsPlaylist()) {
+            final int playlistId = MusicUtil.getOrCreateSkippedPlaylist(this).id;
+            PlaylistsUtil.addToPlaylist(this, getCurrentSong(), playlistId, true);
         }
 
         playSongAt(getNextPosition(force));

--- a/app/src/main/java/com/poupa/vinylmusicplayer/util/MusicUtil.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/util/MusicUtil.java
@@ -7,12 +7,10 @@ import android.content.ContentValues;
 import android.content.Context;
 import android.content.Intent;
 import android.database.Cursor;
-import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Environment;
 import android.provider.BaseColumns;
 import android.provider.MediaStore;
-import android.provider.Settings;
 import android.text.TextUtils;
 import android.widget.Toast;
 
@@ -342,6 +340,10 @@ public class MusicUtil {
 
     private static Playlist getOrCreateFavoritesPlaylist(@NonNull final Context context) {
         return PlaylistLoader.getPlaylist(context, PlaylistsUtil.createPlaylist(context, context.getString(R.string.favorites)));
+    }
+
+    public static Playlist getOrCreateSkippedPlaylist(@NonNull final Context context) {
+        return PlaylistLoader.getPlaylist(context, PlaylistsUtil.createPlaylist(context, context.getString(R.string.skipped_songs)));
     }
 
     public static boolean isFavorite(@NonNull final Context context, @NonNull final Song song) {

--- a/app/src/main/java/com/poupa/vinylmusicplayer/util/PreferenceUtil.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/util/PreferenceUtil.java
@@ -65,6 +65,7 @@ public final class PreferenceUtil {
 
     public static final String LAST_ADDED_CUTOFF = "last_added_interval";
     public static final String RECENTLY_PLAYED_CUTOFF = "recently_played_interval";
+    public static final String MAINTAIN_SKIPPED_SONGS_PLAYLIST = "maintain_skipped_songs_playlist";
 
     public static final String ALBUM_ART_ON_LOCKSCREEN = "album_art_on_lockscreen";
     public static final String BLURRED_ALBUM_ART = "blurred_album_art";
@@ -556,6 +557,9 @@ public final class PreferenceUtil {
         return mPreferences.getBoolean(ANIMATE_PLAYING_SONG_ICON, false);
     }
 
+    public final boolean maintainSkippedSongsPlaylist() {
+        return mPreferences.getBoolean(MAINTAIN_SKIPPED_SONGS_PLAYLIST, false);
+    }
     public void setInitializedBlacklist() {
         final SharedPreferences.Editor editor = mPreferences.edit();
         editor.putBoolean(INITIALIZED_BLACKLIST, true);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -135,6 +135,8 @@
     <string name="pref_title_audio_ducking">Reduce volume on focus loss</string>
     <string name="pref_title_recently_played_interval">Recently played playlist interval</string>
     <string name="pref_title_last_added_interval">Last added playlist interval</string>
+    <string name="pref_title_maintain_skipped_songs_playlist">Skipped songs</string>
+    <string name="pref_summary_maintain_skipped_songs_playlist">Maintain a playlist of song skipped during playback</string>
     <string name="pref_title_synchronized_lyrics_show">Show synchronized lyrics</string>
     <string name="pref_title_animate_playing_song_icon">Animate playing song icon</string>
     <string name="pref_title_remember_last_tab">Remember last tab</string>
@@ -183,6 +185,7 @@
     <string name="history">History</string>
     <string name="my_top_tracks">My top tracks</string>
     <string name="not_recently_played">Not recently played</string>
+    <string name="skipped_songs">Skipped songs</string>
     <string name="remove_cover">Remove cover</string>
     <string name="download_from_last_fm">Download from Last.fm</string>
     <string name="pick_from_local_storage">Pick from local storage</string>

--- a/app/src/main/res/xml/pref_playlists.xml
+++ b/app/src/main/res/xml/pref_playlists.xml
@@ -23,6 +23,13 @@
             android:positiveButtonText="@null"
             android:title="@string/pref_title_last_added_interval" />
 
+        <com.kabouzeid.appthemehelper.common.prefs.supportv7.ATESwitchPreference
+            app:iconSpaceReserved="false"
+            android:defaultValue="false"
+            android:key="maintain_skipped_songs_playlist"
+            android:summary="@string/pref_summary_maintain_skipped_songs_playlist"
+            android:title="@string/pref_title_maintain_skipped_songs_playlist" />
+
     </com.kabouzeid.appthemehelper.common.prefs.supportv7.ATEPreferenceCategory>
 
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
This is a new feature.

If enabled (via settings), a new 'Skipped songs' playlist is created and filled with songs that are manually/explicitly skipped during playback.

Can be considered as a reverse concept of "Favorites" songs. In my case, this helps song triage afterwards.