### PR TITLE
Reduce UI lag

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/loader/AlbumLoader.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/loader/AlbumLoader.java
@@ -53,12 +53,6 @@ public class AlbumLoader {
     }
 
     @NonNull
-    public static Album getAlbum(@NonNull final Context context, String albumName) {
-        ArrayList<Song> songs = SongLoader.getSongs(SongLoader.makeSongCursor(context, AudioColumns.ALBUM + "=?", new String[]{String.valueOf(albumName)}, getSongLoaderSortOrder(context)));
-        return new Album(songs);
-    }
-
-    @NonNull
     public static ArrayList<Album> splitIntoAlbums(@Nullable final ArrayList<Song> songs) {
         ArrayList<Album> albums = new ArrayList<>();
         if (songs != null) {

--- a/app/src/main/java/com/poupa/vinylmusicplayer/loader/ArtistLoader.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/loader/ArtistLoader.java
@@ -55,17 +55,6 @@ public class ArtistLoader {
     }
 
     @NonNull
-    public static Artist getArtist(@NonNull final Context context, String artistName) {
-        ArrayList<Song> songs = SongLoader.getSongs(SongLoader.makeSongCursor(
-                context,
-                AudioColumns.ARTIST + "=?",
-                new String[]{artistName},
-                getSongLoaderSortOrder(context))
-        );
-        return new Artist(AlbumLoader.splitIntoAlbums(songs));
-    }
-
-    @NonNull
     public static ArrayList<Artist> splitIntoArtists(@Nullable final ArrayList<Album> albums) {
         ArrayList<Artist> artists = new ArrayList<>();
         if (albums != null) {

--- a/app/src/main/java/com/poupa/vinylmusicplayer/loader/SongLoader.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/loader/SongLoader.java
@@ -70,7 +70,7 @@ public class SongLoader {
     }
 
     @NonNull
-    public static Song getSong(@Nullable Cursor cursor) {
+    private static Song getSong(@Nullable Cursor cursor) {
         Song song;
         if (cursor != null && cursor.moveToFirst()) {
             song = getSongFromCursorImpl(cursor);

--- a/app/src/main/java/com/poupa/vinylmusicplayer/loader/SortedLongCursor.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/loader/SortedLongCursor.java
@@ -22,7 +22,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 
 /**
@@ -94,16 +93,9 @@ public class SortedLongCursor extends AbstractCursor {
     /**
      * @return the list of ids that weren't found in the underlying cursor
      */
+    @NonNull
     public ArrayList<Long> getMissingIds() {
         return mMissingIds;
-    }
-
-    /**
-     * @return the list of ids that were in the underlying cursor but not part of the ordered list
-     */
-    @NonNull
-    public Collection<Long> getExtraIds() {
-        return mMapCursorPositions.keySet();
     }
 
     @Override

--- a/app/src/main/java/com/poupa/vinylmusicplayer/model/Playlist.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/model/Playlist.java
@@ -34,8 +34,8 @@ public class Playlist implements Parcelable {
         String songCountString = MusicUtil.getSongCountString(context, songCount);
 
         return MusicUtil.buildInfoString(
-            songCountString,
-            ""
+                songCountString,
+                ""
         );
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/provider/HistoryStore.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/provider/HistoryStore.java
@@ -25,6 +25,8 @@ import android.database.sqlite.SQLiteOpenHelper;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import java.util.ArrayList;
+
 public class HistoryStore extends SQLiteOpenHelper {
     public static final String DATABASE_NAME = "history.db";
     private static final int VERSION = 1;
@@ -72,7 +74,7 @@ public class HistoryStore extends SQLiteOpenHelper {
 
         try {
             // remove previous entries
-            removeSongId(songId);
+            removeSongId(database, songId);
 
             // add the entry
             final ContentValues values = new ContentValues(2);
@@ -85,12 +87,25 @@ public class HistoryStore extends SQLiteOpenHelper {
         }
     }
 
-    public void removeSongId(final long songId) {
+    public void removeSongIds(@NonNull ArrayList<Long> missingIds) {
+        if (missingIds.isEmpty()) return;
+
         final SQLiteDatabase database = getWritableDatabase();
+        database.beginTransaction();
+        try {
+            for (long id : missingIds) {
+                removeSongId(database, id);
+            }
+        } finally {
+            database.setTransactionSuccessful();
+            database.endTransaction();
+        }
+    }
+
+    private void removeSongId(@NonNull final SQLiteDatabase database, final long songId) {
         database.delete(RecentStoreColumns.NAME, RecentStoreColumns.ID + " = ?", new String[]{
                 String.valueOf(songId)
         });
-
     }
 
     public void clear() {


### PR DESCRIPTION
Originated from https://github.com/AdrienPoupa/VinylMusicPlayer/pull/271.

This PR reduces UI lag due that are related to building the dynamic playlists, at least to make the app more usable in my case.
The change is quite small, if speed is still an issue a more radical approach might be needed later.

--

- Refactoring of 'not recently played' underlying code to speedup a bit;
- Refactoring of history.db cleanup of orphan ID to mass-remove if
possible