### PR TITLE
Fix the artist page display where the artist name is wrong if he/she is involved in multi-artists album

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/loader/AlbumLoader.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/loader/AlbumLoader.java
@@ -66,7 +66,8 @@ public class AlbumLoader {
         return albums;
     }
 
-    private static Album getOrCreateAlbum(ArrayList<Album> albums, int albumId) {
+    public static Album getOrCreateAlbum(ArrayList<Album> albums, int albumId) {
+        // TODO Avoid sequential search here
         for (Album album : albums) {
             if (!album.songs.isEmpty() && album.songs.get(0).albumId == albumId) {
                 return album;

--- a/app/src/main/java/com/poupa/vinylmusicplayer/loader/ArtistLoader.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/loader/ArtistLoader.java
@@ -29,7 +29,7 @@ public class ArtistLoader {
                 null,
                 getSongLoaderSortOrder(context))
         );
-        return splitIntoArtists(AlbumLoader.splitIntoAlbums(songs));
+        return splitIntoArtists(songs);
     }
 
     @NonNull
@@ -40,7 +40,7 @@ public class ArtistLoader {
                 new String[]{"%" + query + "%"},
                 getSongLoaderSortOrder(context))
         );
-        return splitIntoArtists(AlbumLoader.splitIntoAlbums(songs));
+        return splitIntoArtists(songs);
     }
 
     @NonNull
@@ -55,11 +55,13 @@ public class ArtistLoader {
     }
 
     @NonNull
-    public static ArrayList<Artist> splitIntoArtists(@Nullable final ArrayList<Album> albums) {
+    public static ArrayList<Artist> splitIntoArtists(@Nullable final ArrayList<Song> songs) {
         ArrayList<Artist> artists = new ArrayList<>();
-        if (albums != null) {
-            for (Album album : albums) {
-                getOrCreateArtist(artists, album.getArtistId()).albums.add(album);
+        if (songs != null) {
+            for (Song song : songs) {
+                Artist artist = getOrCreateArtist(artists, song.artistId);
+                Album album = AlbumLoader.getOrCreateAlbum(artist.albums, song.albumId);
+                album.songs.add(song);
             }
         }
         return artists;


### PR DESCRIPTION
Partial fix for https://github.com/AdrienPoupa/VinylMusicPlayer/issues/67 and for https://github.com/AdrienPoupa/VinylMusicPlayer/issues/232

---

The situation:
1. the app internally doesnt make any difference between 'album artist' and 'artist'.
2. it (incorrectly) assumes that there is only 1 artist per album.
3. when a song is a cooperation has multiple artists, there is no commonly agreed way to specify the list of artist (i.e. "A, B" or "A feat. B" or "A;B & C").

Combination of these 3 issues make the display of artist and the navigation inconsistent.

This PR fixes the 2nd item mentioned above. 