### PR TITLE
Cleaner drag indicator in playlist layout

### DIFF
--- a/app/src/main/res/drawable/ic_baseline_drag_indicator_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_drag_indicator_24.xml
@@ -1,0 +1,6 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white"
+        android:pathData="M9,10c-1.1,0 -2,0.9 -2, 2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2zM9,4c"/>
+</vector>

--- a/app/src/main/res/layout/item_list.xml
+++ b/app/src/main/res/layout/item_list.xml
@@ -18,12 +18,12 @@
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
             android:layout_gravity="center_vertical|start"
-            android:layout_marginLeft="-8dp"
-            android:layout_marginStart="-8dp"
+            android:layout_marginLeft="0dp"
+            android:layout_marginStart="0dp"
             android:tint="?attr/iconColor"
             android:tintMode="src_in"
             android:visibility="gone"
-            app:srcCompat="@drawable/ic_drag_vertical_white_24dp"
+            app:srcCompat="@drawable/ic_baseline_drag_indicator_24"
             tools:ignore="ContentDescription" />
 
         <LinearLayout


### PR DESCRIPTION
Cleaner drag indicator for the playlist detail view with better margin
Before:
![Screenshot_20200830-103158_Vinyl_Music_Player](https://user-images.githubusercontent.com/56130419/91654977-a82d3c00-eaad-11ea-99b8-2e04613a22a2.png)

After:
![Screenshot_20200830-103718_Vinyl_DEBUG~2](https://user-images.githubusercontent.com/56130419/91654983-ad8a8680-eaad-11ea-9e7b-5d0873d0c212.png)
