### PR TITLE
Player progress bar take all screen

### DIFF
--- a/app/src/main/res/layout/fragment_card_player_playback_controls.xml
+++ b/app/src/main/res/layout/fragment_card_player_playback_controls.xml
@@ -44,8 +44,8 @@
             android:id="@+id/player_progress_slider"
             style="@style/MusicProgressSlider"
             android:layout_height="match_parent"
-            android:layout_toLeftOf="@id/player_song_total_time"
-            android:layout_toRightOf="@id/player_song_current_progress"
+            android:layout_marginLeft="-14dp"
+            android:layout_marginRight="-14dp"
             tools:ignore="RtlHardcoded,UnusedAttribute" />
 
     </RelativeLayout>

--- a/app/src/main/res/layout/fragment_flat_player_playback_controls.xml
+++ b/app/src/main/res/layout/fragment_flat_player_playback_controls.xml
@@ -45,9 +45,9 @@
         <SeekBar
             android:id="@+id/player_progress_slider"
             style="@style/MusicProgressSlider"
+            android:layout_marginLeft="-14dp"
+            android:layout_marginRight="-14dp"
             android:layout_height="match_parent"
-            android:layout_toLeftOf="@id/player_song_total_time"
-            android:layout_toRightOf="@id/player_song_current_progress"
             tools:ignore="RtlHardcoded,UnusedAttribute" />
 
     </RelativeLayout>


### PR DESCRIPTION
Modification on player progress bar so that it take all screen as it seem more intuitive to change time:
![Screenshot_20200830-103009_Vinyl_DEBUG](https://user-images.githubusercontent.com/56130419/91655054-48836080-eaae-11ea-833e-d7b3313d197b.png)
