### PR TITLE
Detail view text color problem

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/AlbumDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/AlbumDetailActivity.java
@@ -202,6 +202,8 @@ public class AlbumDetailActivity extends AbsSlidingMusicPanelActivity implements
         durationTextView.setTextColor(secondaryTextColor);
         songCountTextView.setTextColor(secondaryTextColor);
         albumYearTextView.setTextColor(secondaryTextColor);
+
+        titleTextView.setTextColor(MaterialValueHelper.getPrimaryTextColor(this, ColorUtil.isColorLight(color)));
     }
 
     @Override

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/ArtistDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/ArtistDetailActivity.java
@@ -310,6 +310,8 @@ public class ArtistDetailActivity extends AbsSlidingMusicPanelActivity implement
         durationTextView.setTextColor(secondaryTextColor);
         songCountTextView.setTextColor(secondaryTextColor);
         albumCountTextView.setTextColor(secondaryTextColor);
+
+        titleTextView.setTextColor(MaterialValueHelper.getPrimaryTextColor(this, ColorUtil.isColorLight(color)));
     }
 
     private void setUpToolbar() {

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/GenreDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/GenreDetailActivity.java
@@ -17,6 +17,8 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.afollestad.materialcab.MaterialCab;
 import com.h6ah4i.android.widget.advrecyclerview.utils.WrapperAdapterUtils;
 import com.kabouzeid.appthemehelper.ThemeStore;
+import com.kabouzeid.appthemehelper.util.ColorUtil;
+import com.kabouzeid.appthemehelper.util.MaterialValueHelper;
 import com.poupa.vinylmusicplayer.R;
 import com.poupa.vinylmusicplayer.adapter.song.SongAdapter;
 import com.poupa.vinylmusicplayer.helper.MusicPlayerRemote;

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/GenreDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/GenreDetailActivity.java
@@ -105,6 +105,8 @@ public class GenreDetailActivity extends AbsSlidingMusicPanelActivity implements
         getSupportActionBar().setTitle(null);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         titleTextView.setText(genre.name);
+
+        titleTextView.setTextColor(MaterialValueHelper.getPrimaryTextColor(this, ColorUtil.isColorLight(ThemeStore.primaryColor(this))));
     }
 
     @Override

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/PlaylistDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/PlaylistDetailActivity.java
@@ -132,6 +132,8 @@ public class PlaylistDetailActivity extends AbsSlidingMusicPanelActivity impleme
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         setToolbarTitle(null);
         titleTextView.setText(playlist.name);
+
+        titleTextView.setTextColor(MaterialValueHelper.getPrimaryTextColor(this, ColorUtil.isColorLight(ThemeStore.primaryColor(this))));
     }
 
     private void setToolbarTitle(String title) {

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/PlaylistDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/PlaylistDetailActivity.java
@@ -20,6 +20,8 @@ import com.h6ah4i.android.widget.advrecyclerview.animator.RefactoredDefaultItemA
 import com.h6ah4i.android.widget.advrecyclerview.draggable.RecyclerViewDragDropManager;
 import com.h6ah4i.android.widget.advrecyclerview.utils.WrapperAdapterUtils;
 import com.kabouzeid.appthemehelper.ThemeStore;
+import com.kabouzeid.appthemehelper.util.ColorUtil;
+import com.kabouzeid.appthemehelper.util.MaterialValueHelper;
 import com.poupa.vinylmusicplayer.R;
 import com.poupa.vinylmusicplayer.adapter.song.OrderablePlaylistSongAdapter;
 import com.poupa.vinylmusicplayer.adapter.song.PlaylistSongAdapter;


### PR DESCRIPTION
Some detail view like album can have the title text and the toolbar with different color. This commit fix this strange behaviour.

Before:
![Screenshot_20200815-200545_Photos](https://user-images.githubusercontent.com/56130419/91655112-b3cd3280-eaae-11ea-96a7-4c1508609bba.png)


After:
![Screenshot_20200815-200551_Photos](https://user-images.githubusercontent.com/56130419/91655117-bc256d80-eaae-11ea-9452-ef71fbe08331.png)

