### PR TITLE
Appshortcut follow correctly the choosen theme

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/appshortcuts/AppShortcutIconGenerator.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/appshortcuts/AppShortcutIconGenerator.java
@@ -45,7 +45,7 @@ public final class AppShortcutIconGenerator {
 
         // Return an Icon of iconId with those colors
         return generateThemedIcon(context, iconId,
-                ThemeStore.primaryColor(context),
+                ThemeStore.accentColor(context),
                 typedColorBackground.data
         );
     }


### PR DESCRIPTION
Icon of appshortcut cannot be the same color than background in dark mode

Before:
![Screenshot_20200806-233913_Photos](https://user-images.githubusercontent.com/56130419/91655208-4bcb1c00-eaaf-11ea-8774-6301a8041feb.png)


After:
![Screenshot_20200830-103045_Nova_Launcher](https://user-images.githubusercontent.com/56130419/91655224-5e455580-eaaf-11ea-88e8-2206f6c5dc8a.png)

