### PR TITLE
Popup menu for material-cab will follow theme

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/AlbumDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/AlbumDetailActivity.java
@@ -370,6 +370,7 @@ public class AlbumDetailActivity extends AbsSlidingMusicPanelActivity implements
                 .setMenu(menuRes)
                 .setCloseDrawableRes(R.drawable.ic_close_white_24dp)
                 .setBackgroundColor(VinylMusicPlayerColorUtil.shiftBackgroundColorForLightText(getPaletteColor()))
+                .setPopupMenuTheme(PreferenceUtil.getInstance().getGeneralTheme())
                 .start(new MaterialCab.Callback() {
                     @Override
                     public boolean onCabCreated(MaterialCab materialCab, Menu menu) {

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/ArtistDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/ArtistDetailActivity.java
@@ -397,6 +397,7 @@ public class ArtistDetailActivity extends AbsSlidingMusicPanelActivity implement
                 .setMenu(menuRes)
                 .setCloseDrawableRes(R.drawable.ic_close_white_24dp)
                 .setBackgroundColor(VinylMusicPlayerColorUtil.shiftBackgroundColorForLightText(getPaletteColor()))
+                .setPopupMenuTheme(PreferenceUtil.getInstance().getGeneralTheme())
                 .start(new MaterialCab.Callback() {
                     @Override
                     public boolean onCabCreated(MaterialCab materialCab, Menu menu) {

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/GenreDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/GenreDetailActivity.java
@@ -27,6 +27,7 @@ import com.poupa.vinylmusicplayer.misc.WrappedAsyncTaskLoader;
 import com.poupa.vinylmusicplayer.model.Genre;
 import com.poupa.vinylmusicplayer.model.Song;
 import com.poupa.vinylmusicplayer.ui.activities.base.AbsSlidingMusicPanelActivity;
+import com.poupa.vinylmusicplayer.util.PreferenceUtil;
 import com.poupa.vinylmusicplayer.util.ViewUtil;
 import com.poupa.vinylmusicplayer.util.VinylMusicPlayerColorUtil;
 import com.simplecityapps.recyclerview_fastscroll.views.FastScrollRecyclerView;
@@ -135,6 +136,7 @@ public class GenreDetailActivity extends AbsSlidingMusicPanelActivity implements
                 .setMenu(menu)
                 .setCloseDrawableRes(R.drawable.ic_close_white_24dp)
                 .setBackgroundColor(VinylMusicPlayerColorUtil.shiftBackgroundColorForLightText(ThemeStore.primaryColor(this)))
+                .setPopupMenuTheme(PreferenceUtil.getInstance().getGeneralTheme())
                 .start(callback);
         return cab;
     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/PlaylistDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/PlaylistDetailActivity.java
@@ -35,6 +35,7 @@ import com.poupa.vinylmusicplayer.model.Playlist;
 import com.poupa.vinylmusicplayer.model.Song;
 import com.poupa.vinylmusicplayer.ui.activities.base.AbsSlidingMusicPanelActivity;
 import com.poupa.vinylmusicplayer.util.PlaylistsUtil;
+import com.poupa.vinylmusicplayer.util.PreferenceUtil;
 import com.poupa.vinylmusicplayer.util.ViewUtil;
 import com.poupa.vinylmusicplayer.util.VinylMusicPlayerColorUtil;
 import com.simplecityapps.recyclerview_fastscroll.views.FastScrollRecyclerView;
@@ -167,6 +168,7 @@ public class PlaylistDetailActivity extends AbsSlidingMusicPanelActivity impleme
                 .setMenu(menu)
                 .setCloseDrawableRes(R.drawable.ic_close_white_24dp)
                 .setBackgroundColor(VinylMusicPlayerColorUtil.shiftBackgroundColorForLightText(ThemeStore.primaryColor(this)))
+                .setPopupMenuTheme(PreferenceUtil.getInstance().getGeneralTheme())
                 .start(callback);
         return cab;
     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/folders/FoldersFragment.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/folders/FoldersFragment.java
@@ -241,6 +241,7 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
                 .setMenu(menuRes)
                 .setCloseDrawableRes(R.drawable.ic_close_white_24dp)
                 .setBackgroundColor(VinylMusicPlayerColorUtil.shiftBackgroundColorForLightText(ThemeStore.primaryColor(getActivity())))
+                .setPopupMenuTheme(PreferenceUtil.getInstance().getGeneralTheme())
                 .start(callback);
         return cab;
     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/library/LibraryFragment.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/library/LibraryFragment.java
@@ -166,6 +166,7 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
                 .setMenu(menuRes)
                 .setCloseDrawableRes(R.drawable.ic_close_white_24dp)
                 .setBackgroundColor(VinylMusicPlayerColorUtil.shiftBackgroundColorForLightText(ThemeStore.primaryColor(getActivity())))
+                .setPopupMenuTheme(PreferenceUtil.getInstance().getGeneralTheme())
                 .start(callback);
         return cab;
     }


### PR DESCRIPTION
Some 3dot menu where not following dark theme

Before:
![Screenshot_20200815-191420_Vinyl_Music_Player](https://user-images.githubusercontent.com/56130419/91655265-b0867680-eaaf-11ea-8803-5b36f8d907b7.png)


After:
![Screenshot_20200815-191431_Vinyl_DEBUG](https://user-images.githubusercontent.com/56130419/91655269-b67c5780-eaaf-11ea-8b3d-ce03b9b1949e.png)
