### PR TITLE
Playlist detail view as a layout problem

### DIFF
--- a/app/src/main/res/layout/activity_playlist_detail.xml
+++ b/app/src/main/res/layout/activity_playlist_detail.xml
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
     android:transitionGroup="true"
     tools:ignore="UnusedAttribute">
-
-    <include layout="@layout/status_bar" />
 
     <!-- for getSwipeableContainerView() -->
     <com.poupa.vinylmusicplayer.views.TouchInterceptFrameLayout
@@ -15,39 +12,55 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <FrameLayout
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="?colorPrimary"
-            android:elevation="@dimen/toolbar_elevation"
-            tools:ignore="UnusedAttribute">
+            android:layout_height="match_parent"
+            android:orientation="vertical">
 
-            <androidx.appcompat.widget.Toolbar
-                android:id="@+id/toolbar"
-                style="@style/Toolbar"
-                android:background="@android:color/transparent">
+            <include layout="@layout/status_bar" />
 
-                <com.poupa.vinylmusicplayer.views.TouchInterceptHorizontalScrollView
-                    android:id="@+id/title_scrollview"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content">
-
-                    <com.poupa.vinylmusicplayer.views.AutoTruncateTextView
-                        android:id="@+id/title"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        style="@style/TextAppearance.AppCompat.Widget.ActionBar.Title" />
-
-                </com.poupa.vinylmusicplayer.views.TouchInterceptHorizontalScrollView>
-
-            </androidx.appcompat.widget.Toolbar>
-
-            <ViewStub
-                android:id="@+id/cab_stub"
+            <FrameLayout
                 android:layout_width="match_parent"
-                android:layout_height="?android:attr/actionBarSize" />
+                android:layout_height="wrap_content"
+                android:background="?colorPrimary"
+                android:elevation="@dimen/toolbar_elevation"
+                tools:ignore="UnusedAttribute">
 
-        </FrameLayout>
+                <androidx.appcompat.widget.Toolbar
+                    android:id="@+id/toolbar"
+                    style="@style/Toolbar"
+                    android:background="@android:color/transparent">
+
+                    <com.poupa.vinylmusicplayer.views.TouchInterceptHorizontalScrollView
+                        android:id="@+id/title_scrollview"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content">
+
+                        <com.poupa.vinylmusicplayer.views.AutoTruncateTextView
+                            android:id="@+id/title"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            style="@style/TextAppearance.AppCompat.Widget.ActionBar.Title" />
+
+                    </com.poupa.vinylmusicplayer.views.TouchInterceptHorizontalScrollView>
+
+                </androidx.appcompat.widget.Toolbar>
+
+                <ViewStub
+                    android:id="@+id/cab_stub"
+                    android:layout_width="match_parent"
+                    android:layout_height="?android:attr/actionBarSize" />
+
+            </FrameLayout>
+
+            <com.simplecityapps.recyclerview_fastscroll.views.FastScrollRecyclerView
+                android:id="@+id/recycler_view"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:clipToPadding="false"
+                android:scrollbars="none" />
+
+        </LinearLayout>
 
         <TextView
             android:id="@android:id/empty"
@@ -61,13 +74,6 @@
             android:textSize="@dimen/empty_text_size"
             android:visibility="gone" />
 
-        <com.simplecityapps.recyclerview_fastscroll.views.FastScrollRecyclerView
-            android:id="@+id/recycler_view"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:clipToPadding="false"
-            android:scrollbars="none" />
-
     </com.poupa.vinylmusicplayer.views.TouchInterceptFrameLayout>
 
-</LinearLayout>
+</FrameLayout>


### PR DESCRIPTION
Correction on the playlist layout (as done per genre layout)
 - toolbar no longer put an unwanted shadow
 - number of title + time as reappear

Before:
![Screenshot_20200830-103158_Vinyl_Music_Player](https://user-images.githubusercontent.com/56130419/91655373-6225a780-eab0-11ea-88d6-02dbc27a8c62.png)


After:
![Screenshot_20200830-110531_Vinyl_DEBUG](https://user-images.githubusercontent.com/56130419/91655441-ccd6e300-eab0-11ea-9a23-b49ddde82531.png)

