### PR TITLE
Playlist bug on Android 10

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.VinylMusicPlayer.Light"
         android:resizeableActivity="true"
+        android:requestLegacyExternalStorage="true"
         tools:ignore="UnusedAttribute">
         <activity android:name="com.poupa.vinylmusicplayer.ui.activities.MainActivity"
             android:theme="@style/SplashTheme"

--- a/app/src/main/java/com/poupa/vinylmusicplayer/util/MusicUtil.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/util/MusicUtil.java
@@ -8,6 +8,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Environment;
 import android.provider.BaseColumns;
 import android.provider.MediaStore;
@@ -297,16 +298,19 @@ public class MusicUtil {
                     activity.getContentResolver().delete(MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
                             selection.toString(), null);
 
-                    // Step 3: Remove files from card
-                    cursor.moveToFirst();
-                    int i = batchStart;
-                    while (!cursor.isAfterLast()) {
-                        final String name = cursor.getString(1);
-                        final Uri safUri = safUris == null || safUris.size() <= i ? null : safUris.get(i);
-                        SAFUtil.delete(activity, name, safUri);
-                        i++;
-                        cursor.moveToNext();
+                    // Step 3: Remove files from card - Android Q takes care of this if the element is remove via MediaStore
+                    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+                        cursor.moveToFirst();
+                        int i = batchStart;
+                        while (!cursor.isAfterLast()) {
+                            final String name = cursor.getString(1);
+                            final Uri safUri = safUris == null || safUris.size() <= i ? null : safUris.get(i);
+                            SAFUtil.delete(activity, name, safUri);
+                            i++;
+                            cursor.moveToNext();
+                        }
                     }
+
                     cursor.close();
                 }
             } catch (SecurityException ignored) {

--- a/app/src/main/java/com/poupa/vinylmusicplayer/util/PlaylistsUtil.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/util/PlaylistsUtil.java
@@ -142,6 +142,7 @@ public class PlaylistsUtil {
                         R.string.inserted_x_songs_into_playlist_x, numInserted, getNameForPlaylist(context, playlistId)), Toast.LENGTH_SHORT).show();
             }
         } catch (SecurityException ignored) {
+            ignored.printStackTrace();
         }
     }
 


### PR DESCRIPTION
Workaround the Android 10 behaviour change.

This tackles https://github.com/AdrienPoupa/VinylMusicPlayer/issues/248, as well as the impossibility to add folder to blacklist.

To dos:
- [x] delete a song works but shows "Can't get SAF URI" toast, which is misleading
- [x] test ID3 tag modification
- [x] android 11 compat check. According to https://developer.android.com/about/versions/11/privacy/storage#scoped-storage this is still tolerated.
