### PR TITLE
Fix crash (possible due to Android Q) on album art modification

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/tageditor/AbsTagEditorActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/tageditor/AbsTagEditorActivity.java
@@ -350,6 +350,7 @@ public abstract class AbsTagEditorActivity extends AbsBaseActivity {
 
                 Artwork artwork = null;
                 File albumArtFile = null;
+                final String albumArtMimeType = "image/png";
                 if (info.artworkInfo != null && info.artworkInfo.artwork != null) {
                     try {
                         albumArtFile = MusicUtil.createAlbumArtFile().getCanonicalFile();
@@ -409,7 +410,11 @@ public abstract class AbsTagEditorActivity extends AbsBaseActivity {
                 Context context = getContext();
                 if (context != null) {
                     if (wroteArtwork) {
-                        MusicUtil.insertAlbumArt(context, info.artworkInfo.albumId, albumArtFile.getPath());
+                        MusicUtil.insertAlbumArt(
+                                context,
+                                info.artworkInfo.albumId,
+                                albumArtFile.getPath(),
+                                albumArtMimeType);
                     } else if (deletedArtwork) {
                         MusicUtil.deleteAlbumArt(context, info.artworkInfo.albumId);
                     }
@@ -446,6 +451,10 @@ public abstract class AbsTagEditorActivity extends AbsBaseActivity {
         }
 
         private void scan(String[] toBeScanned) {
+            if (toBeScanned == null) {
+                return;
+            }
+
             Activity activity = this.activity.get();
             if (activity != null) {
                 MediaScannerConnection.scanFile(activity, toBeScanned, null, new UpdateToastMediaScannerCompletionListener(activity, toBeScanned));

--- a/app/src/main/java/com/poupa/vinylmusicplayer/util/MusicUtil.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/util/MusicUtil.java
@@ -218,15 +218,16 @@ public class MusicUtil {
         return trackNumberToFix % 1000;
     }
 
-    public static void insertAlbumArt(@NonNull Context context, long albumId, String path) {
+    public static void insertAlbumArt(@NonNull Context context, long albumId, String path, @NonNull final String mimeType) {
         ContentResolver contentResolver = context.getContentResolver();
 
         Uri artworkUri = Uri.parse("content://media/external/audio/albumart");
         contentResolver.delete(ContentUris.withAppendedId(artworkUri, albumId), null, null);
 
         ContentValues values = new ContentValues();
-        values.put("album_id", albumId);
-        values.put("_data", path);
+        values.put(MediaStore.Audio.AlbumColumns.ALBUM_ID, albumId);
+        values.put(MediaStore.MediaColumns.MIME_TYPE, mimeType);
+        values.put(MediaStore.MediaColumns.DATA, path);
 
         contentResolver.insert(artworkUri, values);
     }


### PR DESCRIPTION
To reproduce:
- Open album tag editor
- Search for last.fm image
- Save

-> crash with IllegalArgumentException, since ContentResolver.insert expects MIME type = image/*.