### PR TITLE
Multi-disc track sorting

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/AlbumSongAdapter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/AlbumSongAdapter.java
@@ -28,8 +28,7 @@ public class AlbumSongAdapter extends SongAdapter {
         final Song song = dataSet.get(position);
 
         if (holder.imageText != null) {
-            final int trackNumber = MusicUtil.getFixedTrackNumber(song.trackNumber);
-            final String trackNumberString = trackNumber > 0 ? String.valueOf(trackNumber) : "-";
+            final String trackNumberString = MusicUtil.getTrackNumberInfoString(song);
             holder.imageText.setText(trackNumberString);
         }
     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/discog/DB.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/discog/DB.java
@@ -19,7 +19,7 @@ import java.util.Collection;
 
 class DB extends SQLiteOpenHelper {
     private static final String DATABASE_NAME = "discography.db";
-    private static final int VERSION = 3;
+    private static final int VERSION = 4;
 
     public DB() {
         super(App.getInstance().getApplicationContext(), DATABASE_NAME, null, VERSION);
@@ -37,6 +37,7 @@ class DB extends SQLiteOpenHelper {
                         + SongColumns.DATA_PATH + " TEXT, "
                         + SongColumns.DATE_ADDED + " LONG, "
                         + SongColumns.DATE_MODIFIED + " LONG, "
+                        + SongColumns.DISC_NUMBER + " LONG, "
                         + SongColumns.GENRE +  " TEXT, "
                         + SongColumns.REPLAYGAIN_ALBUM + " REAL, "
                         + SongColumns.REPLAYGAIN_TRACK + " REAL, "
@@ -71,6 +72,7 @@ class DB extends SQLiteOpenHelper {
             values.put(SongColumns.DATA_PATH, song.data);
             values.put(SongColumns.DATE_ADDED, song.dateAdded);
             values.put(SongColumns.DATE_MODIFIED, song.dateModified);
+            values.put(SongColumns.DISC_NUMBER, song.discNumber);
             values.put(SongColumns.GENRE, song.genre);
             values.put(SongColumns.REPLAYGAIN_ALBUM, song.getReplayGainAlbum());
             values.put(SongColumns.REPLAYGAIN_TRACK, song.getReplayGainTrack());
@@ -121,6 +123,7 @@ class DB extends SQLiteOpenHelper {
                         SongColumns.DATA_PATH,
                         SongColumns.DATE_ADDED,
                         SongColumns.DATE_MODIFIED,
+                        SongColumns.DISC_NUMBER,
                         SongColumns.GENRE,
                         SongColumns.REPLAYGAIN_ALBUM,
                         SongColumns.REPLAYGAIN_TRACK,
@@ -149,6 +152,7 @@ class DB extends SQLiteOpenHelper {
                 final String dataPath = cursor.getString(++columnIndex);
                 final long dateAdded = cursor.getLong(++columnIndex);
                 final long dateModified = cursor.getLong(++columnIndex);
+                final int discNumber = cursor.getInt(++columnIndex);
                 final String genre = cursor.getString(++columnIndex);
                 final float replayGainAlbum = cursor.getFloat(++columnIndex);
                 final float replayGainTrack = cursor.getFloat(++columnIndex);
@@ -170,6 +174,7 @@ class DB extends SQLiteOpenHelper {
                         albumName,
                         artistId,
                         artistName);
+                song.discNumber = discNumber;
                 song.setReplayGainValues(replayGainTrack, replayGainAlbum);
                 song.genre = genre;
 
@@ -190,6 +195,7 @@ class DB extends SQLiteOpenHelper {
         String DATA_PATH = "data_path";
         String DATE_ADDED = "date_added";
         String DATE_MODIFIED = "date_modified";
+        String DISC_NUMBER = "disc_number";
         String GENRE = "genre";
         String REPLAYGAIN_ALBUM = "replaygain_album";
         String REPLAYGAIN_TRACK = "replaygain_track";

--- a/app/src/main/java/com/poupa/vinylmusicplayer/discog/Discography.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/discog/Discography.java
@@ -272,17 +272,8 @@ public class Discography implements MusicServiceEventListener {
             }
 
             song.genre = tags.getFirst(FieldKey.GENRE);
-
             try {song.discNumber = Integer.parseInt(tags.getFirst(FieldKey.DISC_NO));} catch (NumberFormatException ignored) {}
             try {song.trackNumber = Integer.parseInt(tags.getFirst(FieldKey.TRACK));} catch (NumberFormatException ignored) {}
-            // iTunes uses for example 1002 for track 2 CD1 or 3011 for track 11 CD3.
-            // this method converts those values to normal track numbers
-            final int DISC_NUMBER_DISGUISE_FACTOR = 1000;
-            if (song.discNumber == 0 && song.trackNumber > DISC_NUMBER_DISGUISE_FACTOR) {
-                song.discNumber = (song.trackNumber / DISC_NUMBER_DISGUISE_FACTOR);
-                song.trackNumber = (song.trackNumber % DISC_NUMBER_DISGUISE_FACTOR);
-            }
-
             try {song.year = Integer.parseInt(tags.getFirst(FieldKey.YEAR));} catch (NumberFormatException ignored) {}
 
             ReplayGainTagExtractor.setReplayGainValues(song);

--- a/app/src/main/java/com/poupa/vinylmusicplayer/discog/Discography.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/discog/Discography.java
@@ -272,7 +272,17 @@ public class Discography implements MusicServiceEventListener {
             }
 
             song.genre = tags.getFirst(FieldKey.GENRE);
+
+            try {song.discNumber = Integer.parseInt(tags.getFirst(FieldKey.DISC_NO));} catch (NumberFormatException ignored) {}
             try {song.trackNumber = Integer.parseInt(tags.getFirst(FieldKey.TRACK));} catch (NumberFormatException ignored) {}
+            // iTunes uses for example 1002 for track 2 CD1 or 3011 for track 11 CD3.
+            // this method converts those values to normal track numbers
+            final int DISC_NUMBER_DISGUISE_FACTOR = 1000;
+            if (song.discNumber == 0 && song.trackNumber > DISC_NUMBER_DISGUISE_FACTOR) {
+                song.discNumber = (song.trackNumber / DISC_NUMBER_DISGUISE_FACTOR);
+                song.trackNumber = (song.trackNumber % DISC_NUMBER_DISGUISE_FACTOR);
+            }
+
             try {song.year = Integer.parseInt(tags.getFirst(FieldKey.YEAR));} catch (NumberFormatException ignored) {}
 
             ReplayGainTagExtractor.setReplayGainValues(song);

--- a/app/src/main/java/com/poupa/vinylmusicplayer/discog/MemCache.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/discog/MemCache.java
@@ -50,7 +50,12 @@ class MemCache {
 
         // Only sort albums after the song has been added
         Collections.sort(artist.albums, (a1, a2) -> a1.getYear() - a2.getYear());
-        Collections.sort(album.songs, (s1, s2) -> s1.trackNumber - s2.trackNumber);
+
+        Collections.sort(album.songs,
+                (s1, s2) -> (s1.discNumber != s2.discNumber)
+                        ? (s1.discNumber - s2.discNumber)
+                        : (s1.trackNumber - s2.trackNumber)
+        );
 
         songsById.put(song.id, song);
     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/model/Song.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/model/Song.java
@@ -2,6 +2,7 @@ package com.poupa.vinylmusicplayer.model;
 
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.text.TextUtils;
 
 import com.poupa.vinylmusicplayer.loader.ReplayGainTagExtractor;
 
@@ -14,6 +15,7 @@ public class Song implements Parcelable {
     public final long id;
     public String title;
     public int trackNumber;
+    public int discNumber = 0;
     public int year;
     public final long duration;
     public final String data;
@@ -41,6 +43,7 @@ public class Song implements Parcelable {
         this.albumName = albumName;
         this.artistId = artistId;
         this.artistName = artistName;
+        // Note: Ignore since it's not supported by MediaStore: discNumber, genre
     }
 
     public void setReplayGainValues(float track, float album) {
@@ -73,18 +76,20 @@ public class Song implements Parcelable {
 
         if (id != song.id) return false;
         if (trackNumber != song.trackNumber) return false;
+        // Note: Ignore since it's not supported by MediaStore: if (discNumber != song.discNumber) return false;
         if (year != song.year) return false;
         if (duration != song.duration) return false;
         if (dateAdded != song.dateAdded) return false;
         if (dateModified != song.dateModified) return false;
         if (albumId != song.albumId) return false;
         if (artistId != song.artistId) return false;
-        if (title != null ? !title.equals(song.title) : song.title != null) return false;
-        if (data != null ? !data.equals(song.data) : song.data != null) return false;
-        if (albumName != null ? !albumName.equals(song.albumName) : song.albumName != null)
-            return false;
-        return artistName != null ? artistName.equals(song.artistName) : song.artistName == null;
+        if (!TextUtils.equals(title, song.title)) return false;
+        if (!TextUtils.equals(data, song.data)) return false;
+        if (!TextUtils.equals(albumName, song.albumName)) return false;
+        if (!TextUtils.equals(artistName, song.artistName)) return false;
+        // Note: Ignore since it's not supported by MediaStore: if (!TextUtils.equals(genre, song.genre)) return false;
 
+        return true;
     }
 
     @Override
@@ -92,6 +97,7 @@ public class Song implements Parcelable {
         int result = (int)id;
         result = 31 * result + (title != null ? title.hashCode() : 0);
         result = 31 * result + trackNumber;
+        // Note: Ignore since it's not supported by MediaStore: result = 31 * result + discNumber;
         result = 31 * result + year;
         result = 31 * result + (int) (duration ^ (duration >>> 32));
         result = 31 * result + (data != null ? data.hashCode() : 0);
@@ -101,6 +107,8 @@ public class Song implements Parcelable {
         result = 31 * result + (albumName != null ? albumName.hashCode() : 0);
         result = 31 * result + (int)artistId;
         result = 31 * result + (artistName != null ? artistName.hashCode() : 0);
+        // Note: Ignore since it's not supported by MediaStore: result = 31 * result + (genre != null ? genre.hashCode() : 0);
+
         return result;
     }
 
@@ -110,6 +118,7 @@ public class Song implements Parcelable {
                 "id=" + id +
                 ", title='" + title + '\'' +
                 ", trackNumber=" + trackNumber +
+                ", discNumber=" + discNumber +
                 ", year=" + year +
                 ", duration=" + duration +
                 ", data='" + data + '\'' +
@@ -133,6 +142,7 @@ public class Song implements Parcelable {
         dest.writeLong(this.id);
         dest.writeString(this.title);
         dest.writeInt(this.trackNumber);
+        // Note: Ignore since it's not supported by MediaStore: dest.writeInt(this.discNumber);
         dest.writeInt(this.year);
         dest.writeLong(this.duration);
         dest.writeString(this.data);
@@ -142,12 +152,14 @@ public class Song implements Parcelable {
         dest.writeString(this.albumName);
         dest.writeLong(this.artistId);
         dest.writeString(this.artistName);
+        // Note: Ignore since it's not supported by MediaStore: dest.writeString(this.genre);
     }
 
     protected Song(Parcel in) {
         this.id = in.readLong();
         this.title = in.readString();
         this.trackNumber = in.readInt();
+        // Note: Ignore since it's not supported by MediaStore: this.discNumber = in.readInt();
         this.year = in.readInt();
         this.duration = in.readLong();
         this.data = in.readString();
@@ -157,6 +169,7 @@ public class Song implements Parcelable {
         this.albumName = in.readString();
         this.artistId = in.readLong();
         this.artistName = in.readString();
+        // Note: Ignore since it's not supported by MediaStore: this.genre = in.readString();
     }
 
     public static final Creator<Song> CREATOR = new Creator<Song>() {

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/tageditor/AbsTagEditorActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/tageditor/AbsTagEditorActivity.java
@@ -382,7 +382,12 @@ public abstract class AbsTagEditorActivity extends AbsBaseActivity {
                         if (info.fieldKeyValueMap != null) {
                             for (Map.Entry<FieldKey, String> entry : info.fieldKeyValueMap.entrySet()) {
                                 try {
-                                    tag.setField(entry.getKey(), entry.getValue());
+                                    if (entry.getValue().isEmpty()) {
+                                        tag.deleteField(entry.getKey());
+                                    }
+                                    else {
+                                        tag.setField(entry.getKey(), entry.getValue());
+                                    }
                                 } catch (Exception e) {
                                     e.printStackTrace();
                                 }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/tageditor/AbsTagEditorActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/tageditor/AbsTagEditorActivity.java
@@ -607,6 +607,15 @@ public abstract class AbsTagEditorActivity extends AbsBaseActivity {
     }
 
     @Nullable
+    protected String getDiscNumber() {
+        try {
+            return getAudioFile(songPaths.get(0)).getTagOrCreateAndSetDefault().getFirst(FieldKey.DISC_NO);
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    @Nullable
     protected String getTrackNumber() {
         try {
             return getAudioFile(songPaths.get(0)).getTagOrCreateAndSetDefault().getFirst(FieldKey.TRACK);

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/tageditor/SongTagEditorActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/tageditor/SongTagEditorActivity.java
@@ -35,8 +35,10 @@ public class SongTagEditorActivity extends AbsTagEditorActivity implements TextW
     EditText genre;
     @BindView(R.id.year)
     EditText year;
-    @BindView(R.id.image_text)
+    @BindView(R.id.track_number)
     EditText trackNumber;
+    @BindView(R.id.disc_number)
+    EditText discNumber;
     @BindView(R.id.lyrics)
     EditText lyrics;
 
@@ -60,6 +62,7 @@ public class SongTagEditorActivity extends AbsTagEditorActivity implements TextW
         genre.addTextChangedListener(this);
         year.addTextChangedListener(this);
         trackNumber.addTextChangedListener(this);
+        discNumber.addTextChangedListener(this);
         lyrics.addTextChangedListener(this);
     }
 
@@ -70,6 +73,7 @@ public class SongTagEditorActivity extends AbsTagEditorActivity implements TextW
         genre.setText(getGenreName());
         year.setText(getSongYear());
         trackNumber.setText(getTrackNumber());
+        discNumber.setText(getDiscNumber());
         lyrics.setText(getLyrics());
     }
 
@@ -102,6 +106,7 @@ public class SongTagEditorActivity extends AbsTagEditorActivity implements TextW
         fieldKeyValueMap.put(FieldKey.GENRE, genre.getText().toString());
         fieldKeyValueMap.put(FieldKey.YEAR, year.getText().toString());
         fieldKeyValueMap.put(FieldKey.TRACK, trackNumber.getText().toString());
+        fieldKeyValueMap.put(FieldKey.DISC_NO, discNumber.getText().toString());
         fieldKeyValueMap.put(FieldKey.LYRICS, lyrics.getText().toString());
         writeValuesToFiles(fieldKeyValueMap, null);
     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/util/MusicUtil.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/util/MusicUtil.java
@@ -45,7 +45,6 @@ import java.util.regex.Pattern;
  * @author Karim Abou Zeid (kabouzeid)
  */
 public class MusicUtil {
-
     public static Uri getMediaStoreAlbumCoverUri(long albumId) {
         final Uri sArtworkUri = Uri.parse("content://media/external/audio/albumart");
 
@@ -98,8 +97,9 @@ public class MusicUtil {
     @NonNull
     public static String getSongInfoString(@NonNull final Song song) {
         if (PreferenceUtil.getInstance().showSongNumber()) {
+
             return MusicUtil.buildInfoString(
-                    String.valueOf(getFixedTrackNumber(song.trackNumber)),
+                    MusicUtil.getTrackNumberInfoString(song),
                     song.artistName,
                     song.albumName
             );
@@ -212,10 +212,19 @@ public class MusicUtil {
         return string1 + "  •  " + string2 + "  •  " + string3;
     }
 
-    //iTunes uses for example 1002 for track 2 CD1 or 3011 for track 11 CD3.
-    //this method converts those values to normal tracknumbers
-    public static int getFixedTrackNumber(int trackNumberToFix) {
-        return trackNumberToFix % 1000;
+    @NonNull
+    public static String getTrackNumberInfoString(@NonNull final Song song) {
+        String result = "";
+        if (song.discNumber > 0) {
+            result = String.valueOf(song.discNumber) + "-";
+        }
+        if (song.trackNumber > 0) {
+            result += String.valueOf(song.trackNumber);
+        }
+        else if (result.isEmpty()) {
+            result = "-";
+        }
+        return result;
     }
 
     public static void insertAlbumArt(@NonNull Context context, long albumId, String path, @NonNull final String mimeType) {

--- a/app/src/main/res/layout/activity_song_tag_editor.xml
+++ b/app/src/main/res/layout/activity_song_tag_editor.xml
@@ -150,7 +150,8 @@
                         android:layout_gravity="center"
                         android:fontFamily="sans-serif"
                         android:gravity="center_vertical"
-                        android:inputType="number"
+                        android:hint="@string/track_number"
+                        android:inputType="text|number"
                         android:singleLine="true"
                         android:textAppearance="@style/TextAppearance.AppCompat.Title" />
 
@@ -167,7 +168,8 @@
                         android:layout_gravity="center"
                         android:fontFamily="sans-serif"
                         android:gravity="center_vertical"
-                        android:inputType="number"
+                        android:inputType="text|number"
+                        android:hint="@string/disc_number"
                         android:singleLine="true"
                         android:textAppearance="@style/TextAppearance.AppCompat.Title" />
 

--- a/app/src/main/res/layout/activity_song_tag_editor.xml
+++ b/app/src/main/res/layout/activity_song_tag_editor.xml
@@ -144,14 +144,30 @@
                     android:layout_height="wrap_content">
 
                     <EditText
-                        android:id="@+id/image_text"
+                        android:id="@+id/track_number"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center"
                         android:fontFamily="sans-serif"
                         android:gravity="center_vertical"
-                        android:hint="@string/track_hint"
-                        android:inputType="text|number"
+                        android:inputType="number"
+                        android:singleLine="true"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Title" />
+
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content">
+
+                    <EditText
+                        android:id="@+id/disc_number"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        android:fontFamily="sans-serif"
+                        android:gravity="center_vertical"
+                        android:inputType="number"
                         android:singleLine="true"
                         android:textAppearance="@style/TextAppearance.AppCompat.Title" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,6 +47,8 @@
     <string name="album_artist">Album artist</string>
     <string name="year">Year</string>
     <string name="track_hint">"Track (2 for track 2 or 3004 for CD3 track 4)"</string>
+    <string name="track_number">"Track Number"</string>
+    <string name="disc_number">"Disc Number"</string>
     <string name="lyrics">Lyrics</string>
     <string name="album_or_artist_empty">The title or artist is empty.</string>
     <string name="saving_changes">Saving changes</string>


### PR DESCRIPTION
Fix for https://github.com/AdrienPoupa/VinylMusicPlayer/issues/251

~~Note that this has Discog DB version 4, i.e. conflicting with the discog-v3 branch.~~

Todo:
- [x] Update the tag editor to enable disc number edition
- [x] tag editor: cannot set track/disc number to empty value
- [x] Should we drop the ugly DISC_NUMBER_DISGUISE_FACTOR in the code, or wait for a few release cycle first? 