### PR TITLE
Support ReplayGain in MP4 files

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/loader/ReplayGainTagExtractor.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/loader/ReplayGainTagExtractor.java
@@ -84,11 +84,11 @@ public class ReplayGainTagExtractor {
   private static Map<String, Float> parseVorbisTags(VorbisCommentTag tag) {
     Map<String, Float> tags = new HashMap<>();
 
-    if (tag.hasField("REPLAYGAIN_TRACK_GAIN")) {
-      tags.put(REPLAYGAIN_TRACK_GAIN, parseFloat(tag.getFirst("REPLAYGAIN_TRACK_GAIN")));
+    if (tag.hasField(REPLAYGAIN_TRACK_GAIN)) {
+      tags.put(REPLAYGAIN_TRACK_GAIN, parseFloat(tag.getFirst(REPLAYGAIN_TRACK_GAIN)));
     }
-    if (tag.hasField("REPLAYGAIN_ALBUM_GAIN")) {
-      tags.put(REPLAYGAIN_ALBUM_GAIN, parseFloat(tag.getFirst("REPLAYGAIN_ALBUM_GAIN")));
+    if (tag.hasField(REPLAYGAIN_ALBUM_GAIN)) {
+      tags.put(REPLAYGAIN_ALBUM_GAIN, parseFloat(tag.getFirst(REPLAYGAIN_ALBUM_GAIN)));
     }
 
     return tags;


### PR DESCRIPTION
Adds support for ReplayGain tags in MP4 files. Standard tag names are preferred, but the tag names written by iTunes and loudgain are also supported.