### PR TITLE
Attempt to fix a crash after extended sleep

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
@@ -334,6 +334,7 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
     @Override
     public void onDestroy() {
         unregisterReceiver(widgetIntentReceiver);
+        unregisterReceiver(updateFavoriteReceiver);
         if (becomingNoisyReceiverRegistered) {
             unregisterReceiver(becomingNoisyReceiver);
             becomingNoisyReceiverRegistered = false;


### PR DESCRIPTION
Related Android log:
```
Service com.poupa.vinylmusicplayer.service.MusicService has leaked IntentReceiver com.poupa.vinylmusicplayer.service.MusicService$3@4051cc that was originally registered here. Are you missing a call to unregisterReceiver()?
```