### PR TITLE
Fix crash when a song is removed from queue

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/adapter/AlbumCoverPagerAdapter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/adapter/AlbumCoverPagerAdapter.java
@@ -30,14 +30,17 @@ import static com.poupa.vinylmusicplayer.util.ViewUtil.VINYL_ALBUM_ART_SCALE_TYP
  */
 public class AlbumCoverPagerAdapter extends CustomFragmentStatePagerAdapter {
 
-    private ArrayList<Song> dataSet;
+    private final ArrayList<Song> dataSet;
 
     private AlbumCoverFragment.ColorReceiver currentColorReceiver;
     private int currentColorReceiverPosition = -1;
 
     public AlbumCoverPagerAdapter(FragmentManager fm, ArrayList<Song> dataSet) {
         super(fm);
-        this.dataSet = dataSet;
+        // Make a copy to avoid race condition
+        // i.e. the playing queue is modified, the UI code detects the change and crash
+        // before this class gets a chance to be notified
+        this.dataSet = new ArrayList<>(dataSet);
     }
 
     @Override


### PR DESCRIPTION
java.lang.IllegalStateException: The application's PagerAdapter changed the adapter's contents without calling PagerAdapter#notifyDataSetChanged!
      Expected adapter item count: 2243, found: 2242
      Pager id: com.poupa.vinylmusicplayer.ci:id/player_album_cover_viewpager
      Pager class: class androidx.viewpager.widget.ViewPager
      Problematic adapter: class com.poupa.vinylmusicplayer.adapter.AlbumCoverPagerAdapter
            at androidx.viewpager.widget.ViewPager.populate(Unknown Source:569)
            at androidx.viewpager.widget.ViewPager.populate(Unknown Source:2)
            at androidx.viewpager.widget.ViewPager$3.run(Unknown Source:8)