### PR TITLE
Crash songs removal

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/discog/MediaStoreBridge.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/discog/MediaStoreBridge.java
@@ -52,9 +52,6 @@ public class MediaStoreBridge {
                 songs.add(getSongFromCursorImpl(cursor));
             } while (cursor.moveToNext());
         }
-
-        if (cursor != null)
-            cursor.close();
         return songs;
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MediaStoreObserver.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MediaStoreObserver.java
@@ -5,7 +5,7 @@ import android.os.Handler;
 
 public class MediaStoreObserver extends ContentObserver implements Runnable {
     // milliseconds to delay before calling refresh to aggregate events
-    private static final long REFRESH_DELAY = 50;
+    private static final long REFRESH_DELAY = 500;
     private Handler mHandler;
     private MusicService mMusicService;
 


### PR DESCRIPTION
I'm experiencing the following crash after removing a bunch of song files from the storage.

MediaStore picks it up and delivers a Observer.onChange notification. My guess is that this notification is delivered while the rescan is still in progress, and more removals are yet to be processed.

Discog picks up the notification and start iterating on the new DB content -> crash:

```
  02-14 19:24:56.491 15139 29069 E AndroidRuntime: FATAL EXCEPTION: AsyncTask #53
  02-14 19:24:56.491 15139 29069 E AndroidRuntime: Process: com.poupa.vinylmusicplayer.ci, PID: 15139
  02-14 19:24:56.491 15139 29069 E AndroidRuntime: java.lang.RuntimeException: An error occurred while executing doInBackground()
  02-14 19:24:56.491 15139 29069 E AndroidRuntime:        at android.os.AsyncTask$4.done(AsyncTask.java:399)
  02-14 19:24:56.491 15139 29069 E AndroidRuntime:        at java.util.concurrent.FutureTask.finishCompletion(FutureTask.java:383)
  02-14 19:24:56.491 15139 29069 E AndroidRuntime:        at java.util.concurrent.FutureTask.setException(FutureTask.java:252)
  02-14 19:24:56.491 15139 29069 E AndroidRuntime:        at java.util.concurrent.FutureTask.run(FutureTask.java:271)
  02-14 19:24:56.491 15139 29069 E AndroidRuntime:        at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:289)
  02-14 19:24:56.491 15139 29069 E AndroidRuntime:        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
  02-14 19:24:56.491 15139 29069 E AndroidRuntime:        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
  02-14 19:24:56.491 15139 29069 E AndroidRuntime:        at java.lang.Thread.run(Thread.java:919)
  02-14 19:24:56.491 15139 29069 E AndroidRuntime: Caused by: java.lang.IllegalStateException: Couldn't read row 2175, col 0 from CursorWindow.  Make sure the Cursor is initialized correctly before accessing data from it.
  02-14 19:24:56.491 15139 29069 E AndroidRuntime:        at android.database.CursorWindow.nativeGetLong(Native Method)
  02-14 19:24:56.491 15139 29069 E AndroidRuntime:        at android.database.CursorWindow.getLong(CursorWindow.java:542)
  02-14 19:24:56.491 15139 29069 E AndroidRuntime:        at android.database.AbstractWindowedCursor.getLong(AbstractWindowedCursor.java:77)
  02-14 19:24:56.491 15139 29069 E AndroidRuntime:        at android.database.CursorWrapper.getLong(CursorWrapper.java:131)
  02-14 19:24:56.491 15139 29069 E AndroidRuntime:        at com.poupa.vinylmusicplayer.discog.MediaStoreBridge.getSongFromCursorImpl(Unknown Source:3)
  02-14 19:24:56.491 15139 29069 E AndroidRuntime:        at com.poupa.vinylmusicplayer.discog.MediaStoreBridge.getSongs(Unknown Source:13)
  02-14 19:24:56.491 15139 29069 E AndroidRuntime:        at com.poupa.vinylmusicplayer.discog.MediaStoreBridge.getAllSongs(Unknown Source:4)
  02-14 19:24:56.491 15139 29069 E AndroidRuntime:        at com.poupa.vinylmusicplayer.discog.Discography.syncWithMediaStore(Unknown Source:23)
  02-14 19:24:56.491 15139 29069 E AndroidRuntime:        at com.poupa.vinylmusicplayer.discog.Discography.access$100(Unknown Source:0)
  02-14 19:24:56.491 15139 29069 E AndroidRuntime:        at com.poupa.vinylmusicplayer.discog.Discography$1.doInBackground(Unknown Source:11)
  02-14 19:24:56.491 15139 29069 E AndroidRuntime:        at com.poupa.vinylmusicplayer.discog.Discography$1.doInBackground(Unknown Source:2)
  02-14 19:24:56.491 15139 29069 E AndroidRuntime:        at android.os.AsyncTask$3.call(AsyncTask.java:378)
  02-14 19:24:56.491 15139 29069 E AndroidRuntime:        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
  02-14 19:24:56.491 15139 29069 E AndroidRuntime:        ... 4 more
```

The proposed (fragile) solution is to revert back the throttle delay to the previous value (0.5 sec), to give more chance to the MediaStore scan to finish the ongoing scan.

The cleaner solution would be to use transaction/locking to protect DB the  from being concurrently accessed.