### PR TITLE
Fixes for Android Auto

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/auto/AutoMediaIDHelper.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/auto/AutoMediaIDHelper.java
@@ -11,7 +11,9 @@ public class AutoMediaIDHelper {
     public static final String MEDIA_ID_EMPTY_ROOT = "__EMPTY_ROOT__";
     public static final String MEDIA_ID_ROOT = "__ROOT__";
     public static final String MEDIA_ID_MUSICS_BY_SEARCH = "__BY_SEARCH__";  // TODO
+    public static final String MEDIA_ID_MUSICS_BY_LAST_ADDED = "__BY_LAST_ADDED__";
     public static final String MEDIA_ID_MUSICS_BY_HISTORY = "__BY_HISTORY__";
+    public static final String MEDIA_ID_MUSICS_BY_NOT_RECENTLY_PLAYED = "__BY_NOT_RECENTLY_PLAYED__";
     public static final String MEDIA_ID_MUSICS_BY_TOP_TRACKS = "__BY_TOP_TRACKS__";
     public static final String MEDIA_ID_MUSICS_BY_PLAYLIST = "__BY_PLAYLIST__";
     public static final String MEDIA_ID_MUSICS_BY_ALBUM = "__BY_ALBUM__";

--- a/app/src/main/java/com/poupa/vinylmusicplayer/auto/AutoMusicProvider.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/auto/AutoMusicProvider.java
@@ -2,7 +2,6 @@ package com.poupa.vinylmusicplayer.auto;
 
 import android.content.Context;
 import android.content.res.Resources;
-import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.support.v4.media.MediaBrowserCompat;
@@ -22,7 +21,6 @@ import com.poupa.vinylmusicplayer.model.Album;
 import com.poupa.vinylmusicplayer.model.Artist;
 import com.poupa.vinylmusicplayer.model.Playlist;
 import com.poupa.vinylmusicplayer.model.Song;
-import com.poupa.vinylmusicplayer.provider.MusicPlaybackQueueStore;
 import com.poupa.vinylmusicplayer.service.MusicService;
 import com.poupa.vinylmusicplayer.util.ImageUtil;
 
@@ -38,9 +36,6 @@ import java.util.concurrent.ConcurrentSkipListMap;
  * Created by Beesham Sarendranauth (Beesham)
  */
 public class AutoMusicProvider {
-
-    private static final String TAG = AutoMusicProvider.class.getName();
-
     private static final String BASE_URI = "androidauto://vinyl";
     private static final int PATH_SEGMENT_ID = 0;
     private static final int PATH_SEGMENT_TITLE = 1;
@@ -58,8 +53,6 @@ public class AutoMusicProvider {
     private ConcurrentMap<Integer, Uri> mMusicListByAlbum;
     private ConcurrentMap<Integer, Uri> mMusicListByArtist;
 
-    private final Uri defaultAlbumArtUri;
-
     private final Context mContext;
     private volatile State mCurrentState = State.NON_INITIALIZED;
 
@@ -74,10 +67,6 @@ public class AutoMusicProvider {
         mMusicListByPlaylist = new ConcurrentSkipListMap<>();
         mMusicListByAlbum = new ConcurrentSkipListMap<>();
         mMusicListByArtist = new ConcurrentSkipListMap<>();
-
-        defaultAlbumArtUri = Uri.parse("android.resource://" +
-                mContext.getPackageName() + "/drawable/" +
-                mContext.getResources().getResourceEntryName(R.drawable.default_album_art));
     }
 
     public Iterable<Uri> getLastAdded() {
@@ -349,7 +338,7 @@ public class AutoMusicProvider {
                 mediaItems.add(createBrowsableMediaItem(AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_PLAYLIST, resources.getString(R.string.playlists_label), R.drawable.ic_queue_music_white_24dp));
                 mediaItems.add(createBrowsableMediaItem(AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_ALBUM, resources.getString(R.string.albums_label), R.drawable.ic_album_white_24dp));
                 mediaItems.add(createBrowsableMediaItem(AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_ARTIST, resources.getString(R.string.artists_label), R.drawable.ic_people_white_24dp));
-                mediaItems.add(createPlayableMediaItem(AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_SHUFFLE, resources.getString(R.string.action_shuffle_all), R.drawable.ic_shuffle_white_24dp, null));
+                mediaItems.add(createPlayableMediaItem(AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_SHUFFLE, resources.getString(R.string.action_shuffle_all), R.drawable.ic_shuffle_white_24dp));
                 mediaItems.add(createBrowsableMediaItem(AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_QUEUE, resources.getString(R.string.queue_label), R.drawable.ic_playlist_play_white_24dp));
                 break;
 
@@ -418,12 +407,6 @@ public class AutoMusicProvider {
 
     private MediaBrowserCompat.MediaItem createPlayableMediaItem(String mediaId, Uri musicSelection,
                                                                  String title, @Nullable String subtitle) {
-        return createPlayableMediaItem(mediaId, musicSelection, title, subtitle, null, null);
-    }
-
-    private MediaBrowserCompat.MediaItem createPlayableMediaItem(String mediaId, Uri musicSelection,
-                                                                 String title, @Nullable String subtitle,
-                                                                 @Nullable Bitmap albumArt, @Nullable Resources resources) {
         MediaDescriptionCompat.Builder builder = new MediaDescriptionCompat.Builder();
         builder.setMediaId(AutoMediaIDHelper.createMediaID(musicSelection.getPathSegments().get(PATH_SEGMENT_ID), mediaId))
                 .setTitle(title);
@@ -432,28 +415,15 @@ public class AutoMusicProvider {
             builder.setSubtitle(subtitle);
         }
 
-        if (resources != null) {
-            if (albumArt != null) {
-                builder.setIconBitmap(albumArt);
-            } else {
-                builder.setIconUri(defaultAlbumArtUri);
-            }
-        }
-
         return new MediaBrowserCompat.MediaItem(builder.build(),
                 MediaBrowserCompat.MediaItem.FLAG_PLAYABLE);
     }
 
-    private MediaBrowserCompat.MediaItem createPlayableMediaItem(String mediaId, String title, int iconDrawableId,
-                                                                 @Nullable String subtitle) {
+    private MediaBrowserCompat.MediaItem createPlayableMediaItem(String mediaId, String title, int iconDrawableId) {
         MediaDescriptionCompat.Builder builder = new MediaDescriptionCompat.Builder()
                 .setMediaId(mediaId)
                 .setTitle(title)
                 .setIconBitmap(ImageUtil.createBitmap(ImageUtil.getTintedVectorDrawable(mContext, iconDrawableId, ThemeStore.textColorSecondary(mContext))));
-
-        if (subtitle != null) {
-            builder.setSubtitle(subtitle);
-        }
 
         return new MediaBrowserCompat.MediaItem(builder.build(),
                 MediaBrowserCompat.MediaItem.FLAG_PLAYABLE);

--- a/app/src/main/java/com/poupa/vinylmusicplayer/auto/AutoMusicProvider.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/auto/AutoMusicProvider.java
@@ -139,7 +139,12 @@ public class AutoMusicProvider {
 
         final MusicService service = mMusicService.get();
         if (service != null) {
-            final List<Song> songs = MusicPlaybackQueueStore.getInstance(service).getSavedOriginalPlayingQueue();
+            // TODO Why getting the queue from the saved storage and not directly from music service?
+            // final List<Song> songs = MusicPlaybackQueueStore.getInstance(service).getSavedOriginalPlayingQueue();
+
+            final int PLAYING_WINDOW_SIZE = 100;
+            final int position = service.getPosition();
+            final List<Song> songs = service.getPlayingQueue().subList(position, position + PLAYING_WINDOW_SIZE - 1);
             for (int i = 0; i < songs.size(); i++) {
                 final Song s = songs.get(i);
                 Uri.Builder topTracksData = Uri.parse(BASE_URI).buildUpon();

--- a/app/src/main/java/com/poupa/vinylmusicplayer/auto/AutoMusicProvider.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/auto/AutoMusicProvider.java
@@ -46,7 +46,7 @@ public class AutoMusicProvider {
     private static final int PATH_SEGMENT_ARTIST = 2;
     private static final int PATH_SEGMENT_ALBUM_ID = 3;
 
-    private WeakReference<MusicService> mMusicService;
+    private final WeakReference<MusicService> mMusicService;
 
     // Categorized caches for music data
     private ConcurrentMap<Integer, Uri> mMusicListByHistory;
@@ -55,13 +55,14 @@ public class AutoMusicProvider {
     private ConcurrentMap<Integer, Uri> mMusicListByAlbum;
     private ConcurrentMap<Integer, Uri> mMusicListByArtist;
 
-    private Uri defaultAlbumArtUri;
+    private final Uri defaultAlbumArtUri;
 
-    private Context mContext;
+    private final Context mContext;
     private volatile State mCurrentState = State.NON_INITIALIZED;
 
-    public AutoMusicProvider(Context context) {
-        mContext = context;
+    public AutoMusicProvider(MusicService musicService) {
+        mContext = musicService;
+        mMusicService = new WeakReference<>(musicService);
 
         mMusicListByHistory = new ConcurrentSkipListMap<>();
         mMusicListByTopTracks = new ConcurrentSkipListMap<>();
@@ -72,10 +73,6 @@ public class AutoMusicProvider {
         defaultAlbumArtUri = Uri.parse("android.resource://" +
                 mContext.getPackageName() + "/drawable/" +
                 mContext.getResources().getResourceEntryName(R.drawable.default_album_art));
-    }
-
-    public void setMusicService(MusicService service) {
-        mMusicService = new WeakReference<>(service);
     }
 
     public Iterable<Uri> getHistory() {
@@ -284,6 +281,7 @@ public class AutoMusicProvider {
 
         switch (mediaId) {
             case AutoMediaIDHelper.MEDIA_ID_ROOT:
+                // TODO Add not recently played
                 mediaItems.add(createBrowsableMediaItem(AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_HISTORY, resources.getString(R.string.history_label), R.drawable.ic_access_time_white_24dp));
                 mediaItems.add(createBrowsableMediaItem(AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_TOP_TRACKS, resources.getString(R.string.top_tracks_label), R.drawable.ic_trending_up_white_24dp));
                 mediaItems.add(createBrowsableMediaItem(AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_PLAYLIST, resources.getString(R.string.playlists_label), R.drawable.ic_queue_music_white_24dp));

--- a/app/src/main/java/com/poupa/vinylmusicplayer/auto/AutoMusicProvider.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/auto/AutoMusicProvider.java
@@ -77,56 +77,56 @@ public class AutoMusicProvider {
         mMusicListByArtist = new ConcurrentSkipListMap<>();
     }
 
-    public Iterable<Uri> getLastAdded() {
+    private Iterable<Uri> getLastAdded() {
         if (mCurrentState != State.INITIALIZED) {
             return Collections.emptyList();
         }
         return mMusicListByLastAdded.values();
     }
 
-    public Iterable<Uri> getHistory() {
+    private Iterable<Uri> getHistory() {
         if (mCurrentState != State.INITIALIZED) {
             return Collections.emptyList();
         }
         return mMusicListByHistory.values();
     }
 
-    public Iterable<Uri> getNotRecentlyPlayed() {
+    private Iterable<Uri> getNotRecentlyPlayed() {
         if (mCurrentState != State.INITIALIZED) {
             return Collections.emptyList();
         }
         return mMusicListByNotRecentlyPlayed.values();
     }
 
-    public Iterable<Uri> getTopTracks() {
+    private Iterable<Uri> getTopTracks() {
         if (mCurrentState != State.INITIALIZED) {
             return Collections.emptyList();
         }
         return mMusicListByTopTracks.values();
     }
 
-    public Iterable<Uri> getPlaylists() {
+    private Iterable<Uri> getPlaylists() {
         if (mCurrentState != State.INITIALIZED) {
             return Collections.emptyList();
         }
         return mMusicListByPlaylist.values();
     }
 
-    public Iterable<Uri> getAlbums() {
+    private Iterable<Uri> getAlbums() {
         if (mCurrentState != State.INITIALIZED) {
             return Collections.emptyList();
         }
         return mMusicListByAlbum.values();
     }
 
-    public Iterable<Uri> getArtists() {
+    private Iterable<Uri> getArtists() {
         if (mCurrentState != State.INITIALIZED) {
             return Collections.emptyList();
         }
         return mMusicListByArtist.values();
     }
 
-    public Iterable<Uri> getQueue() {
+    private Iterable<Uri> getQueue() {
         if (mCurrentState != State.INITIALIZED) {
             return Collections.emptyList();
         }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/auto/AutoMusicProvider.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/auto/AutoMusicProvider.java
@@ -297,46 +297,18 @@ public class AutoMusicProvider {
                 mediaItems.add(createBrowsableMediaItem(AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_HISTORY, resources.getString(R.string.history_label), R.drawable.ic_access_time_white_24dp));
                 mediaItems.add(createBrowsableMediaItem(AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_NOT_RECENTLY_PLAYED, resources.getString(R.string.not_recently_played), R.drawable.ic_watch_later_white_24dp));
                 mediaItems.add(createBrowsableMediaItem(AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_TOP_TRACKS, resources.getString(R.string.top_tracks_label), R.drawable.ic_trending_up_white_24dp));
+
                 mediaItems.add(createBrowsableMediaItem(AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_PLAYLIST, resources.getString(R.string.playlists_label), R.drawable.ic_queue_music_white_24dp));
                 mediaItems.add(createBrowsableMediaItem(AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_ALBUM, resources.getString(R.string.albums_label), R.drawable.ic_album_white_24dp));
                 mediaItems.add(createBrowsableMediaItem(AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_ARTIST, resources.getString(R.string.artists_label), R.drawable.ic_people_white_24dp));
+
                 mediaItems.add(createPlayableMediaItem(AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_SHUFFLE, resources.getString(R.string.action_shuffle_all), R.drawable.ic_shuffle_white_24dp));
                 mediaItems.add(createBrowsableMediaItem(AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_QUEUE, resources.getString(R.string.queue_label), R.drawable.ic_playlist_play_white_24dp));
-                break;
-
-            case AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_LAST_ADDED:
-                for (final Uri uri : getLastAdded()) {
-                    mediaItems.add(createPlayableMediaItem(mediaId, uri, uri.getPathSegments().get(PATH_SEGMENT_TITLE), uri.getPathSegments().get(PATH_SEGMENT_ARTIST)));
-                }
-                break;
-
-            case AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_HISTORY:
-                for (final Uri uri : getHistory()) {
-                    mediaItems.add(createPlayableMediaItem(mediaId, uri, uri.getPathSegments().get(PATH_SEGMENT_TITLE), uri.getPathSegments().get(PATH_SEGMENT_ARTIST)));
-                }
-                break;
-
-            case AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_NOT_RECENTLY_PLAYED:
-                for (final Uri uri : getNotRecentlyPlayed()) {
-                    mediaItems.add(createPlayableMediaItem(mediaId, uri, uri.getPathSegments().get(PATH_SEGMENT_TITLE), uri.getPathSegments().get(PATH_SEGMENT_ARTIST)));
-                }
-                break;
-
-            case AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_TOP_TRACKS:
-                for (final Uri uri : getTopTracks()) {
-                    mediaItems.add(createPlayableMediaItem(mediaId, uri, uri.getPathSegments().get(PATH_SEGMENT_TITLE), uri.getPathSegments().get(PATH_SEGMENT_ARTIST)));
-                }
                 break;
 
             case AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_PLAYLIST:
                 for (final Uri uri : getPlaylists()) {
                     mediaItems.add(createPlayableMediaItem(mediaId, uri, uri.getPathSegments().get(PATH_SEGMENT_TITLE), null));
-                }
-                break;
-
-            case AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_ALBUM:
-                for (final Uri uri : getAlbums()) {
-                    mediaItems.add(createPlayableMediaItem(mediaId, uri, uri.getPathSegments().get(PATH_SEGMENT_TITLE), uri.getPathSegments().get(PATH_SEGMENT_ARTIST)));
                 }
                 break;
 
@@ -346,9 +318,33 @@ public class AutoMusicProvider {
                 }
                 break;
 
-            case AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_QUEUE:
-                for (final Uri uri : getQueue()) {
-                    mediaItems.add(createPlayableMediaItem(mediaId, uri, uri.getPathSegments().get(PATH_SEGMENT_TITLE), uri.getPathSegments().get(PATH_SEGMENT_ARTIST)));
+            default:
+                Iterable<Uri> listing = null;
+                switch (mediaId) {
+                    case AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_LAST_ADDED:
+                        listing = getLastAdded();
+                        break;
+                    case AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_HISTORY:
+                        listing = getHistory();
+                        break;
+                    case AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_NOT_RECENTLY_PLAYED:
+                        listing = getNotRecentlyPlayed();
+                        break;
+                    case AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_TOP_TRACKS:
+                        listing = getTopTracks();
+                        break;
+                    case AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_ALBUM:
+                        listing = getAlbums();
+                        break;
+                    case AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_QUEUE:
+                        listing = getQueue();
+                        break;
+                }
+                if (listing != null) {
+                    for (final Uri uri : listing) {
+                        final List<String> segments = uri.getPathSegments();
+                        mediaItems.add(createPlayableMediaItem(mediaId, uri, segments.get(PATH_SEGMENT_TITLE), segments.get(PATH_SEGMENT_ARTIST)));
+                    }
                 }
                 break;
         }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/helper/MusicPlayerRemote.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/helper/MusicPlayerRemote.java
@@ -21,6 +21,7 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.poupa.vinylmusicplayer.App;
 import com.poupa.vinylmusicplayer.R;
 import com.poupa.vinylmusicplayer.discog.Discography;
 import com.poupa.vinylmusicplayer.model.Song;
@@ -187,6 +188,8 @@ public class MusicPlayerRemote {
             if (!PreferenceUtil.getInstance().rememberShuffle()){
                 setShuffleMode(MusicService.SHUFFLE_MODE_NONE);
             }
+        } else {
+            Toast.makeText(App.getStaticContext(), "openQueue: Cannot play" + (musicService == null ? " - music service is NULL" : ""), Toast.LENGTH_LONG).show();
         }
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/helper/MusicPlayerRemote.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/helper/MusicPlayerRemote.java
@@ -21,7 +21,6 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.poupa.vinylmusicplayer.App;
 import com.poupa.vinylmusicplayer.R;
 import com.poupa.vinylmusicplayer.discog.Discography;
 import com.poupa.vinylmusicplayer.model.Song;
@@ -188,9 +187,10 @@ public class MusicPlayerRemote {
             if (!PreferenceUtil.getInstance().rememberShuffle()){
                 setShuffleMode(MusicService.SHUFFLE_MODE_NONE);
             }
-        } else {
-            Toast.makeText(App.getStaticContext(), "openQueue: Cannot play" + (musicService == null ? " - music service is NULL" : ""), Toast.LENGTH_LONG).show();
         }
+        // else TODO We are stuck here, impossible to start a new queue.
+        //      This happens if the MusicService has been recycled (after extended time) or not started
+        //      To reproduce: Force close, then launch Auto and try starting a new playing queue
     }
 
     /**

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MediaSessionCallback.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MediaSessionCallback.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.v4.media.session.MediaSessionCompat;
 import android.util.Log;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 
@@ -53,8 +54,11 @@ public final class MediaSessionCallback extends MediaSessionCompat.Callback {
     public void onPlayFromMediaId(String mediaId, Bundle extras) {
         super.onPlayFromMediaId(mediaId, extras);
 
+        // TODO Investigate why, if the media is playing, then we cannot trigger a new queue here
+        Toast.makeText(context, "onPlayFromMediaId: " + mediaId, Toast.LENGTH_LONG).show();
+
         final String musicId = AutoMediaIDHelper.extractMusicID(mediaId);
-        final int itemId = musicId != null ? Integer.valueOf(musicId) : -1;
+        final int itemId = musicId != null ? Integer.parseInt(musicId) : -1;
         final ArrayList<Song> songs = new ArrayList<>();
 
         final String category = AutoMediaIDHelper.extractCategory(mediaId);

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MediaSessionCallback.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MediaSessionCallback.java
@@ -13,6 +13,7 @@ import com.poupa.vinylmusicplayer.discog.Discography;
 import com.poupa.vinylmusicplayer.helper.ShuffleHelper;
 import com.poupa.vinylmusicplayer.loader.AlbumLoader;
 import com.poupa.vinylmusicplayer.loader.ArtistLoader;
+import com.poupa.vinylmusicplayer.loader.LastAddedLoader;
 import com.poupa.vinylmusicplayer.loader.PlaylistLoader;
 import com.poupa.vinylmusicplayer.loader.TopAndRecentlyPlayedTracksLoader;
 import com.poupa.vinylmusicplayer.model.Album;
@@ -76,12 +77,18 @@ public final class MediaSessionCallback extends MediaSessionCompat.Callback {
                 openQueue(songs, 0, true);
                 break;
 
+            case AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_LAST_ADDED:
             case AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_HISTORY:
+            case AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_NOT_RECENTLY_PLAYED:
             case AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_TOP_TRACKS:
             case AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_QUEUE:
                 List<Song> tracks;
-                if (category.equals(AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_HISTORY)) {
+                if (category.equals(AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_LAST_ADDED)) {
+                    tracks = LastAddedLoader.getLastAddedSongs();
+                } else if (category.equals(AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_HISTORY)) {
                     tracks = TopAndRecentlyPlayedTracksLoader.getRecentlyPlayedTracks(context);
+                } else if (category.equals(AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_NOT_RECENTLY_PLAYED)) {
+                    tracks = TopAndRecentlyPlayedTracksLoader.getNotRecentlyPlayedTracks(context);
                 } else if (category.equals(AutoMediaIDHelper.MEDIA_ID_MUSICS_BY_TOP_TRACKS)) {
                     tracks = TopAndRecentlyPlayedTracksLoader.getTopTracks(context);
                 } else {

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MediaSessionCallback.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MediaSessionCallback.java
@@ -5,7 +5,6 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.v4.media.session.MediaSessionCompat;
 import android.util.Log;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 
@@ -53,9 +52,6 @@ public final class MediaSessionCallback extends MediaSessionCompat.Callback {
     @Override
     public void onPlayFromMediaId(String mediaId, Bundle extras) {
         super.onPlayFromMediaId(mediaId, extras);
-
-        // TODO Investigate why, if the media is playing, then we cannot trigger a new queue here
-        Toast.makeText(context, "onPlayFromMediaId: " + mediaId, Toast.LENGTH_LONG).show();
 
         final String musicId = AutoMediaIDHelper.extractMusicID(mediaId);
         final int itemId = musicId != null ? Integer.parseInt(musicId) : -1;

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
@@ -880,21 +880,6 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
         }
     }
 
-    public void playSongs(ArrayList<Song> songs, int shuffleMode) {
-        if (songs != null && !songs.isEmpty()) {
-            if (shuffleMode == SHUFFLE_MODE_SHUFFLE) {
-                int startPosition = new Random().nextInt(songs.size());
-                openQueue(songs, startPosition, false);
-                setShuffleMode(shuffleMode);
-            } else {
-                openQueue(songs, 0, false);
-            }
-            play();
-        } else {
-            Toast.makeText(getApplicationContext(), R.string.playlist_is_empty, Toast.LENGTH_LONG).show();
-        }
-    }
-
     private void applyReplayGain() {
         byte mode = PreferenceUtil.getInstance().getReplayGainSourceMode();
         if (mode != PreferenceUtil.RG_SOURCE_MODE_NONE) {


### PR DESCRIPTION
- [x] Fix crasher on Auto -> open queue (uninitialized pointer to MusicService)
  ```
    02-21 13:53:24.677  4645  4645 E AndroidRuntime: FATAL EXCEPTION: main
    02-21 13:53:24.677  4645  4645 E AndroidRuntime: Process: com.poupa.vinylmusicplayer.ci, PID: 4645
    02-21 13:53:24.677  4645  4645 E AndroidRuntime: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.Object java.lang.ref.WeakReference.get()' on a null object reference
    02-21 13:53:24.677  4645  4645 E AndroidRuntime:        at com.poupa.vinylmusicplayer.auto.AutoMusicProvider.getQueue(Unknown Source:18)
    02-21 13:53:24.677  4645  4645 E AndroidRuntime:        at com.poupa.vinylmusicplayer.auto.AutoMusicProvider.getChildren(Unknown Source:450)
    02-21 13:53:24.677  4645  4645 E AndroidRuntime:        at com.poupa.vinylmusicplayer.service.MusicService.onLoadChildren(Unknown Source:31)
    02-21 13:53:24.677  4645  4645 E AndroidRuntime:        at androidx.media.MediaBrowserServiceCompat.performLoadChildren(Unknown Source:16)
    02-21 13:53:24.677  4645  4645 E AndroidRuntime:        at androidx.media.MediaBrowserServiceCompat.addSubscription(Unknown Source:60)
    02-21 13:53:24.677  4645  4645 E AndroidRuntime:        at androidx.media.MediaBrowserServiceCompat$ServiceBinderImpl$3.run(Unknown Source:51)
   ...
   ```
- [x] Add "not recently played" and "last added" playlists to Auto UI
- [x] Fix the ever-spinning load screen for queue and playlist (only happen if the queue/playlist is big)