### PR TITLE
Optimization: Dont open the audio file again in ReplayGainTagExtractor

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/discog/tagging/TagExtractor.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/discog/tagging/TagExtractor.java
@@ -55,7 +55,9 @@ public class TagExtractor {
             song.trackNumber = safeGetTagAsInteger.apply(tags, FieldKey.TRACK);
             song.year = safeGetTagAsInteger.apply(tags, FieldKey.YEAR);
 
-            ReplayGainTagExtractor.setReplayGainValues(song);
+            ReplayGainTagExtractor.ReplayGainValues rgValues = ReplayGainTagExtractor.setReplayGainValues(file);
+            song.replayGainAlbum = rgValues.album;
+            song.replayGainTrack = rgValues.track;
         } catch (Exception e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
On my setup, this yields 15-25% performance gain on a full library rescan