### PR TITLE
Switch theme based on OS setting

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/util/PreferenceUtil.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/util/PreferenceUtil.java
@@ -1,8 +1,8 @@
 package com.poupa.vinylmusicplayer.util;
 
-
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.res.Configuration;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.net.Uri;
@@ -167,11 +167,18 @@ public final class PreferenceUtil {
 
     @StyleRes
     public static int getThemeResFromPrefValue(String themePrefValue) {
+        final int uiMode = App.getInstance().getResources().getConfiguration().uiMode;
+        final boolean nightMode = (uiMode & Configuration.UI_MODE_NIGHT_YES) != 0;
+
         switch (themePrefValue) {
             case "dark":
                 return R.style.Theme_VinylMusicPlayer;
             case "black":
                 return R.style.Theme_VinylMusicPlayer_Black;
+            case "auto_light_dark":
+                return nightMode ? R.style.Theme_VinylMusicPlayer : R.style.Theme_VinylMusicPlayer_Light;
+            case "auto_light_black":
+                return nightMode ? R.style.Theme_VinylMusicPlayer_Black : R.style.Theme_VinylMusicPlayer_Light;
             case "light":
             default:
                 return R.style.Theme_VinylMusicPlayer_Light;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -106,6 +106,8 @@
     <string name="light_theme_name">Light</string>
     <string name="dark_theme_name">Dark</string>
     <string name="black_theme_name">Black (AMOLED)</string>
+    <string name="auto_light_dark_theme_name">Auto Light/Dark</string>
+    <string name="auto_light_black_theme_name">Auto Light/Black (AMOLED)</string>
     <string name="always">Always</string>
     <string name="only_on_wifi">Only on Wi-Fi</string>
     <string name="never">Never</string>

--- a/app/src/main/res/values/strings_activity_settings.xml
+++ b/app/src/main/res/values/strings_activity_settings.xml
@@ -4,12 +4,16 @@
         <item>@string/light_theme_name</item>
         <item>@string/dark_theme_name</item>
         <item>@string/black_theme_name</item>
+        <item>@string/auto_light_dark_theme_name</item>
+        <item>@string/auto_light_black_theme_name</item>
     </string-array>
 
     <string-array name="pref_general_theme_list_values">
         <item>light</item>
         <item>dark</item>
         <item>black</item>
+        <item>auto_light_dark</item>
+        <item>auto_light_black</item>
     </string-array>
 
     <string-array name="pref_auto_download_images_titles">


### PR DESCRIPTION
*EXPERIMENTAL* Support for https://github.com/AdrienPoupa/VinylMusicPlayer/issues/406

User can choose in Settings screen, either a static theme (light/dark/black) or an automatic switch (light/dark or light/black).

On auto mode: theme switching happens when System dark mode is enabled or not.

This is *EXPERIMENTAL*, ie not tested and I dont have the mean to test on different device configurations. 