### PR TITLE
Android 11 media notifications

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/auto/AutoMediaIDHelper.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/auto/AutoMediaIDHelper.java
@@ -8,7 +8,6 @@ import androidx.annotation.NonNull;
 public class AutoMediaIDHelper {
 
     // Media IDs used on browseable items of MediaBrowser
-    public static final String MEDIA_ID_EMPTY_ROOT = "__EMPTY_ROOT__";
     public static final String MEDIA_ID_ROOT = "__ROOT__";
     public static final String MEDIA_ID_MUSICS_BY_SEARCH = "__BY_SEARCH__";  // TODO
     public static final String MEDIA_ID_MUSICS_BY_LAST_ADDED = "__BY_LAST_ADDED__";

--- a/app/src/main/java/com/poupa/vinylmusicplayer/helper/MusicPlayerRemote.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/helper/MusicPlayerRemote.java
@@ -75,6 +75,9 @@ public class MusicPlayerRemote {
         }
         mContextWrapper.unbindService(mBinder);
         if (mConnectionMap.isEmpty()) {
+            if (!musicService.isPlaying()) {
+                musicService.quit();
+            }
             musicService = null;
         }
     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
@@ -1216,8 +1216,7 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
     public BrowserRoot onGetRoot(@NonNull String clientPackageName, int clientUid, @Nullable Bundle rootHints) {
         // Check origin to ensure we're not allowing any arbitrary app to browse app contents
         if (!mPackageValidator.isKnownCaller(clientPackageName, clientUid)) {
-            // Request from an untrusted package: return an empty browser root
-            return new BrowserRoot(AutoMediaIDHelper.MEDIA_ID_EMPTY_ROOT, null);
+            return null;
         }
 
         // System UI query (Android 11+)
@@ -1238,11 +1237,7 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
 
     @Override
     public void onLoadChildren(@NonNull final String parentId, @NonNull final Result<List<MediaBrowserCompat.MediaItem>> result) {
-        if (AutoMediaIDHelper.MEDIA_ID_EMPTY_ROOT.equals(parentId)) {
-            result.sendResult(new ArrayList<>());
-        } else {
-            result.sendResult(mMusicProvider.getChildren(parentId, getResources()));
-        }
+        result.sendResult(mMusicProvider.getChildren(parentId, getResources()));
     }
 
     public Playback getPlayback() {

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
@@ -32,6 +32,7 @@ import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.util.Predicate;
 import androidx.media.MediaBrowserServiceCompat;
 
 import com.bumptech.glide.request.transition.Transition;
@@ -1220,15 +1221,17 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
         }
 
         // System UI query (Android 11+)
-        // By returning null, we explicitly dont want to support content discovery/suggestions
-        if ((rootHints != null) && (Build.VERSION.SDK_INT > Build.VERSION_CODES.Q)) {
-            if (rootHints.getBoolean(BrowserRoot.EXTRA_RECENT)) {
-                return null;
-            } else if (rootHints.getBoolean(BrowserRoot.EXTRA_SUGGESTED)) {
-                return null;
-            } else if (rootHints.getBoolean(BrowserRoot.EXTRA_OFFLINE)) {
-                return null;
-            }
+        Predicate<Bundle> isSystemMediaQuery = (hints) -> {
+            if (hints == null) {return false;}
+            if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q) {return false;}
+            if (hints.getBoolean(BrowserRoot.EXTRA_RECENT)) {return true;}
+            if (hints.getBoolean(BrowserRoot.EXTRA_SUGGESTED)) {return true;}
+            if (hints.getBoolean(BrowserRoot.EXTRA_OFFLINE)) {return true;}
+            return false;
+        };
+        if (isSystemMediaQuery.test(rootHints)) {
+            // By returning null, we explicitly disable support for content discovery/suggestions
+            return null;
         }
 
         // TODO Limit to Android Auto

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
@@ -1220,9 +1220,19 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
             return new BrowserRoot(AutoMediaIDHelper.MEDIA_ID_EMPTY_ROOT, null);
         }
 
-        // TODO Make use of the hints - https://developer.android.com/reference/androidx/media/utils/MediaConstants#constants_1
-        // BROWSER_ROOT_HINTS_KEY_MEDIA_ART_SIZE_PIXELS
-        // BROWSER_ROOT_HINTS_KEY_ROOT_CHILDREN_LIMIT
+        // System UI query (Android 11+)
+        // By returning null, we explicitly dont want to support content discovery/suggestions
+        if ((rootHints != null) && (Build.VERSION.SDK_INT > Build.VERSION_CODES.Q)) {
+            if (rootHints.getBoolean(BrowserRoot.EXTRA_RECENT)) {
+                return null;
+            } else if (rootHints.getBoolean(BrowserRoot.EXTRA_SUGGESTED)) {
+                return null;
+            } else if (rootHints.getBoolean(BrowserRoot.EXTRA_OFFLINE)) {
+                return null;
+            }
+        }
+
+        // TODO Limit to Android Auto
         return new BrowserRoot(AutoMediaIDHelper.MEDIA_ID_ROOT, null);
     }
 


### PR DESCRIPTION
- [x] Cleanup the music service (hence the notifications) if activity is killed (fixes https://github.com/AdrienPoupa/VinylMusicPlayer/issues/443)
- [x] Reduce notification overload by disabling support for {recent|suggested|offline} media discovery queries