### PR TITLE
Avoid crash on reading MP3 tags on Nougat

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/dialogs/SongDetailDialog.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/dialogs/SongDetailDialog.java
@@ -114,7 +114,7 @@ public class SongDetailDialog extends DialogFragment {
                         replayGainValues = context.getString(R.string.none);
                     }
                     replayGain.setText(makeTextWithTitle(context, R.string.label_replay_gain, replayGainValues));
-                } catch (@NonNull CannotReadException | IOException | TagException | ReadOnlyFileException | InvalidAudioFrameException e) {
+                } catch (@NonNull CannotReadException | IOException | TagException | ReadOnlyFileException | InvalidAudioFrameException | NoSuchMethodError e) {
                     Log.e(TAG, "error while reading the song file", e);
                     // fallback
                     trackLength.setText(makeTextWithTitle(context, R.string.label_track_length, MusicUtil.getReadableDurationString(song.duration)));

--- a/app/src/main/java/com/poupa/vinylmusicplayer/discog/tagging/TagExtractor.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/discog/tagging/TagExtractor.java
@@ -66,7 +66,7 @@ public class TagExtractor {
             ReplayGainTagExtractor.ReplayGainValues rgValues = ReplayGainTagExtractor.setReplayGainValues(file);
             song.replayGainAlbum = rgValues.album;
             song.replayGainTrack = rgValues.track;
-        } catch (Exception e) {
+        } catch (@NonNull Exception | NoSuchMethodError e) {
             e.printStackTrace();
         }
     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/tageditor/AbsTagEditorActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/tageditor/AbsTagEditorActivity.java
@@ -409,7 +409,7 @@ public abstract class AbsTagEditorActivity extends AbsBaseActivity {
                         Activity activity = this.activity.get();
 
                         SAFUtil.write(activity, audioFile, safUri);
-                    } catch (@NonNull Exception e) {
+                    } catch (@NonNull Exception | NoSuchMethodError e) {
                         e.printStackTrace();
                     }
                 }
@@ -550,7 +550,7 @@ public abstract class AbsTagEditorActivity extends AbsBaseActivity {
     private AudioFile getAudioFile(@NonNull String path) {
         try {
             return AudioFileIO.read(new File(path));
-        } catch (Exception e) {
+        } catch (@NonNull Exception | NoSuchMethodError e) {
             Log.e(TAG, "Could not read audio file " + path, e);
             return new AudioFile();
         }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/util/MusicUtil.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/util/MusicUtil.java
@@ -398,7 +398,7 @@ public class MusicUtil {
 
         try {
             lyrics = AudioFileIO.read(file).getTagOrCreateDefault().getFirst(FieldKey.LYRICS);
-        } catch (Exception e) {
+        } catch (@NonNull Exception | NoSuchMethodError e) {
             e.printStackTrace();
         }
 


### PR DESCRIPTION
This PR offers a limited work around for https://github.com/AdrienPoupa/VinylMusicPlayer/issues/445, where the MP3 tags cannot be extracted from the file by the jaudiotagger lib. 
Following limitations apply:
- The track metadata relies on the OS MediaStore (with known limits - bad support for accented chars, no multiartist support, etc)
- No tag editor