### PR TITLE
Update italian translation

### DIFF
--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -251,7 +251,6 @@
     <string name="nothing_to_scan">Nulla da scansionare.</string>
     <string name="scanned_files">Scansione effettuata per %1$d su %2$d file.</string>
     <string name="could_not_scan_files">Non è stato possibile effettuare la scansione di %d file.</string>
-    <string name="listing_files">Creazione elenco dei brani...</string>
     <string name="scanning_x_songs_in_progress">Aggiornamento di %1$d brani…</string>
     <string name="scanning_x_songs_finished">Aggiornati %1$d brani</string>
     <string name="listing_files">Lettura dei file</string>					


### PR DESCRIPTION
Remove duplicated line

Maybe you could use a translation platform such as https://crowdin.com/, it's free and would ease translation updates and avoid errors like this one.