### PR TITLE
Prevent repeating last track when gapless is enabled (fixes #435)

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
@@ -490,7 +490,11 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
         synchronized (this) {
             try {
                 int nextPosition = getNextPosition(false);
-                playback.setNextDataSource(getTrackUri(getSongAt(nextPosition)));
+                if (getRepeatMode() == MusicService.REPEAT_MODE_NONE && isLastTrack()) {
+                    playback.setNextDataSource(null);
+                } else {
+                    playback.setNextDataSource(getTrackUri(getSongAt(nextPosition)));
+                }
                 this.nextPosition = nextPosition;
             } catch (Exception e) {
                 e.printStackTrace();

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/PlaybackHandler.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/PlaybackHandler.java
@@ -58,13 +58,9 @@ final class PlaybackHandler extends Handler {
                 break;
 
             case MusicService.TRACK_WENT_TO_NEXT:
-                if (service.getRepeatMode() == MusicService.REPEAT_MODE_NONE && service.isLastTrack()) {
-                    service.pause();
-                } else {
-                    service.setPositionToNextPosition();
-                    service.prepareNextImpl();
-                    service.notifyChange(MusicService.META_CHANGED);
-                }
+                service.setPositionToNextPosition();
+                service.prepareNextImpl();
+                service.notifyChange(MusicService.META_CHANGED);
                 break;
 
             case MusicService.TRACK_ENDED:


### PR DESCRIPTION
With this fix, the media player for the next track is set to null when playing the last track with repeat mode disabled. It was previously initialized with the same track, that's why the track was played again. If repeat mode is enabled, it works the same as before. Also, there's no need to try to pause the player when handling message TRACK_WENT_TO_NEXT because the message is not sent for the last track if repeat mode is disabled.