### PR TITLE
Better menuItem visual queue for delete action

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/adapter/PlaylistAdapter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/adapter/PlaylistAdapter.java
@@ -24,6 +24,7 @@ import com.poupa.vinylmusicplayer.adapter.base.MediaEntryViewHolder;
 import com.poupa.vinylmusicplayer.databinding.ItemListSingleRowBinding;
 import com.poupa.vinylmusicplayer.dialogs.ClearSmartPlaylistDialog;
 import com.poupa.vinylmusicplayer.dialogs.DeletePlaylistDialog;
+import com.poupa.vinylmusicplayer.helper.menu.MenuHelper;
 import com.poupa.vinylmusicplayer.helper.menu.PlaylistMenuHelper;
 import com.poupa.vinylmusicplayer.helper.menu.SongsMenuHelper;
 import com.poupa.vinylmusicplayer.interfaces.CabHolder;
@@ -278,6 +279,9 @@ public class PlaylistAdapter extends AbsMultiSelectAdapter<PlaylistAdapter.ViewH
                     }
                     else {
                         popupMenu.inflate(R.menu.menu_item_playlist);
+
+                        MenuHelper.setDeleteMenuItemRed(popupMenu.getMenu(), activity);
+
                         popupMenu.setOnMenuItemClickListener(item -> PlaylistMenuHelper.handleMenuClick(
                             activity, dataSet.get(getAdapterPosition()), item));
                     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/helper/menu/MenuHelper.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/helper/menu/MenuHelper.java
@@ -4,9 +4,11 @@ package com.poupa.vinylmusicplayer.helper.menu;
 import android.content.Context;
 import android.text.SpannableString;
 import android.text.style.ForegroundColorSpan;
+import android.util.TypedValue;
 import android.view.Menu;
 import android.view.MenuItem;
 
+import androidx.annotation.ColorInt;
 import androidx.core.content.ContextCompat;
 import com.poupa.vinylmusicplayer.R;
 
@@ -21,7 +23,12 @@ public class MenuHelper {
 
         if (liveItem != null) {
             SpannableString s = new SpannableString(liveItem.getTitle().toString());
-            int color = ContextCompat.getColor(context, R.color.delete);
+
+            // Get delete color from context's theme
+            final TypedValue typedColorBackground = new TypedValue();
+            context.getTheme().resolveAttribute(R.attr.md_delete, typedColorBackground, true);
+            @ColorInt int color = typedColorBackground.data;
+
             s.setSpan(new ForegroundColorSpan(color), 0, s.length(), 0);
             liveItem.setTitle(s);
         }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/helper/menu/MenuHelper.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/helper/menu/MenuHelper.java
@@ -1,0 +1,29 @@
+package com.poupa.vinylmusicplayer.helper.menu;
+
+
+import android.content.Context;
+import android.text.SpannableString;
+import android.text.style.ForegroundColorSpan;
+import android.view.Menu;
+import android.view.MenuItem;
+
+import androidx.core.content.ContextCompat;
+import com.poupa.vinylmusicplayer.R;
+
+
+public class MenuHelper {
+
+    public static void setDeleteMenuItemRed(Menu menu, Context context) {
+        // All delete element inside of menu should have red text to better differentiate them
+        MenuItem liveItem = menu.findItem(R.id.action_delete_playlist);
+        if (liveItem == null)
+            liveItem = menu.findItem(R.id.action_delete_from_device);
+
+        if (liveItem != null) {
+            SpannableString s = new SpannableString(liveItem.getTitle().toString());
+            int color = ContextCompat.getColor(context, R.color.delete);
+            s.setSpan(new ForegroundColorSpan(color), 0, s.length(), 0);
+            liveItem.setTitle(s);
+        }
+    }
+}

--- a/app/src/main/java/com/poupa/vinylmusicplayer/helper/menu/SongMenuHelper.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/helper/menu/SongMenuHelper.java
@@ -88,6 +88,9 @@ public class SongMenuHelper {
             PopupMenu popupMenu = new PopupMenu(activity, v);
             popupMenu.inflate(getMenuRes());
             popupMenu.setOnMenuItemClickListener(this);
+
+            MenuHelper.setDeleteMenuItemRed(popupMenu.getMenu(), v.getContext());
+
             popupMenu.show();
         }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/AlbumDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/AlbumDetailActivity.java
@@ -264,7 +264,7 @@ public class AlbumDetailActivity extends AbsSlidingMusicPanelActivity implements
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.menu_album_detail, menu);
 
-        MenuHelper.setDeleteMenuItemRed(menu, this.getApplicationContext());
+        MenuHelper.setDeleteMenuItemRed(menu, this);
 
         return super.onCreateOptionsMenu(menu);
     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/AlbumDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/AlbumDetailActivity.java
@@ -38,6 +38,7 @@ import com.poupa.vinylmusicplayer.glide.GlideApp;
 import com.poupa.vinylmusicplayer.glide.VinylColoredTarget;
 import com.poupa.vinylmusicplayer.glide.VinylGlideExtension;
 import com.poupa.vinylmusicplayer.helper.MusicPlayerRemote;
+import com.poupa.vinylmusicplayer.helper.menu.MenuHelper;
 import com.poupa.vinylmusicplayer.interfaces.CabHolder;
 import com.poupa.vinylmusicplayer.interfaces.LoaderIds;
 import com.poupa.vinylmusicplayer.interfaces.PaletteColorHolder;
@@ -262,6 +263,9 @@ public class AlbumDetailActivity extends AbsSlidingMusicPanelActivity implements
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.menu_album_detail, menu);
+
+        MenuHelper.setDeleteMenuItemRed(menu, this.getApplicationContext());
+
         return super.onCreateOptionsMenu(menu);
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/PlaylistDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/PlaylistDetailActivity.java
@@ -29,6 +29,7 @@ import com.poupa.vinylmusicplayer.adapter.song.SongAdapter;
 import com.poupa.vinylmusicplayer.databinding.ActivityPlaylistDetailBinding;
 import com.poupa.vinylmusicplayer.databinding.SlidingMusicPanelLayoutBinding;
 import com.poupa.vinylmusicplayer.helper.MusicPlayerRemote;
+import com.poupa.vinylmusicplayer.helper.menu.MenuHelper;
 import com.poupa.vinylmusicplayer.helper.menu.PlaylistMenuHelper;
 import com.poupa.vinylmusicplayer.interfaces.CabHolder;
 import com.poupa.vinylmusicplayer.interfaces.LoaderIds;
@@ -150,6 +151,7 @@ public class PlaylistDetailActivity extends AbsSlidingMusicPanelActivity impleme
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(playlist instanceof AbsCustomPlaylist ? R.menu.menu_smart_playlist_detail : R.menu.menu_playlist_detail, menu);
+        MenuHelper.setDeleteMenuItemRed(menu, this);
         return super.onCreateOptionsMenu(menu);
     }
 

--- a/app/src/main/res/menu/menu_item_playlist.xml
+++ b/app/src/main/res/menu/menu_item_playlist.xml
@@ -17,10 +17,10 @@
         android:id="@+id/action_rename_playlist"
         android:title="@string/action_rename" />
     <item
-        android:id="@+id/action_delete_playlist"
-        android:title="@string/action_delete" />
-    <item
         android:id="@+id/action_save_playlist"
         android:title="@string/save_playlist_title" />
+    <item
+        android:id="@+id/action_delete_playlist"
+        android:title="@string/action_delete" />
 
 </menu>

--- a/app/src/main/res/menu/menu_playlist_detail.xml
+++ b/app/src/main/res/menu/menu_playlist_detail.xml
@@ -28,12 +28,12 @@
         android:title="@string/action_rename"
         app:showAsAction="never" />
     <item
-        android:id="@+id/action_delete_playlist"
-        android:title="@string/action_delete"
-        app:showAsAction="never" />
-    <item
         android:id="@+id/action_save_playlist"
         android:title="@string/save_playlist_title"
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/action_delete_playlist"
+        android:title="@string/action_delete"
         app:showAsAction="never" />
 
 </menu>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -10,5 +10,6 @@
 
     <color name="transparent">#00000000</color>
 
+    <color name="delete">#da3500</color>
 
 </resources>

--- a/app/src/main/res/values/styles_parents.xml
+++ b/app/src/main/res/values/styles_parents.xml
@@ -28,6 +28,8 @@
         <item name="android:actionOverflowButtonStyle">@style/Widget.ActionButton.Overflow</item>
 
         <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
+
+        <item name="md_delete">@color/delete</item>
     </style>
 
     <style name="Theme.VinylMusicPlayer.Base.Light" parent="Theme.MaterialComponents.Light.NoActionBar.Bridge">
@@ -57,6 +59,8 @@
         <item name="android:actionOverflowButtonStyle">@style/Widget.ActionButton.Overflow</item>
 
         <item name="preferenceTheme">@style/PreferenceThemeOverlay</item>
+
+        <item name="md_delete">@color/delete</item>
     </style>
 
     <style name="Theme.VinylMusicPlayer.Base.Black" parent="@style/Theme.VinylMusicPlayer.Base">
@@ -65,6 +69,8 @@
         <item name="defaultFooterColor">@color/md_grey_800</item>
         <item name="cardBackgroundColor">@color/md_grey_900</item>
         <item name="md_background_color">@color/md_grey_900</item>
+
+        <item name="md_delete">@color/delete</item>
     </style>
 
     <style name="FabParent">

--- a/app/src/main/res/values/values.xml
+++ b/app/src/main/res/values/values.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <attr format="color" name="md_delete"/>
     <string name="transition_album_art" translatable="false">album_art_transition</string>
     <string name="transition_artist_image" translatable="false">artist_image_transition</string>
     <string name="transition_fab" translatable="false">fab_transition</string>


### PR DESCRIPTION
All menuItem that delete something are red for better indication:
![Screenshot_20210818-163551](https://user-images.githubusercontent.com/56130419/129918895-63bc35fe-9d26-4615-b316-be461d31299b.png)
![Screenshot_20210818-163545](https://user-images.githubusercontent.com/56130419/129918916-8d6f7914-91c3-4fd6-85de-54a96af3728a.png)
![Screenshot_20210818-163537](https://user-images.githubusercontent.com/56130419/129918924-da679a11-d4a3-4d9a-9f23-52ac63a96435.png)
![Screenshot_20210818-163519](https://user-images.githubusercontent.com/56130419/129918933-06034716-c453-483d-934c-d2500bd68497.png)

