### PR TITLE
Set imageText visibility to INVISIBLE from GONE to allow reordering current song in queue

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/util/PlayingSongDecorationUtil.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/util/PlayingSongDecorationUtil.java
@@ -115,7 +115,7 @@ public class PlayingSongDecorationUtil {
         }
 
         if (imageText != null) {
-            imageText.setVisibility((isPlaying || showAlbumImage) ? View.GONE : View.VISIBLE);
+            imageText.setVisibility((isPlaying || showAlbumImage) ? View.INVISIBLE : View.VISIBLE);
         }
     }
 


### PR DESCRIPTION
Fixes #189.

Need input on whether this change is ok for the case in which showAlbumCover is true, or if GONE is better suited for that case.