### PR TITLE
Adding missing red menu item delete in all multiselecion menu

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/adapter/PlaylistAdapter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/adapter/PlaylistAdapter.java
@@ -280,7 +280,7 @@ public class PlaylistAdapter extends AbsMultiSelectAdapter<PlaylistAdapter.ViewH
                     else {
                         popupMenu.inflate(R.menu.menu_item_playlist);
 
-                        MenuHelper.setDeleteMenuItemRed(popupMenu.getMenu(), activity);
+                        MenuHelper.decorateDestructiveItems(popupMenu.getMenu(), activity);
 
                         popupMenu.setOnMenuItemClickListener(item -> PlaylistMenuHelper.handleMenuClick(
                             activity, dataSet.get(getAdapterPosition()), item));

--- a/app/src/main/java/com/poupa/vinylmusicplayer/helper/menu/MenuHelper.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/helper/menu/MenuHelper.java
@@ -9,13 +9,20 @@ import android.view.Menu;
 import android.view.MenuItem;
 
 import androidx.annotation.ColorInt;
+import androidx.annotation.MenuRes;
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.content.ContextCompat;
+import com.afollestad.materialcab.MaterialCab;
+import com.kabouzeid.appthemehelper.ThemeStore;
 import com.poupa.vinylmusicplayer.R;
+import com.poupa.vinylmusicplayer.util.PreferenceUtil;
+import com.poupa.vinylmusicplayer.util.VinylMusicPlayerColorUtil;
 
 
 public class MenuHelper {
 
-    public static void setDeleteMenuItemRed(Menu menu, Context context) {
+    public static void decorateDestructiveItems(Menu menu, Context context) {
         // All delete element inside of menu should have red text to better differentiate them
         MenuItem liveItem = menu.findItem(R.id.action_delete_playlist);
         if (liveItem == null)
@@ -32,5 +39,13 @@ public class MenuHelper {
             s.setSpan(new ForegroundColorSpan(color), 0, s.length(), 0);
             liveItem.setTitle(s);
         }
+    }
+
+    public static MaterialCab setOverflowMenu(@NonNull AppCompatActivity context, @MenuRes int menuRes, @ColorInt int backgroundColor) {
+        return new MaterialCab(context, R.id.cab_stub)
+                .setMenu(menuRes)
+                .setCloseDrawableRes(R.drawable.ic_close_white_24dp)
+                .setBackgroundColor(VinylMusicPlayerColorUtil.shiftBackgroundColorForLightText(backgroundColor))
+                .setPopupMenuTheme(PreferenceUtil.getInstance().getGeneralTheme());
     }
 }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/helper/menu/SongMenuHelper.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/helper/menu/SongMenuHelper.java
@@ -89,7 +89,7 @@ public class SongMenuHelper {
             popupMenu.inflate(getMenuRes());
             popupMenu.setOnMenuItemClickListener(this);
 
-            MenuHelper.setDeleteMenuItemRed(popupMenu.getMenu(), v.getContext());
+            MenuHelper.decorateDestructiveItems(popupMenu.getMenu(), v.getContext());
 
             popupMenu.show();
         }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/AlbumDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/AlbumDetailActivity.java
@@ -56,7 +56,6 @@ import com.poupa.vinylmusicplayer.util.ImageTheme.ThemeStyleUtil;
 import com.poupa.vinylmusicplayer.util.MusicUtil;
 import com.poupa.vinylmusicplayer.util.NavigationUtil;
 import com.poupa.vinylmusicplayer.util.PreferenceUtil;
-import com.poupa.vinylmusicplayer.util.VinylMusicPlayerColorUtil;
 
 import java.util.ArrayList;
 import java.util.Locale;
@@ -264,7 +263,7 @@ public class AlbumDetailActivity extends AbsSlidingMusicPanelActivity implements
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.menu_album_detail, menu);
 
-        MenuHelper.setDeleteMenuItemRed(menu, this);
+        MenuHelper.decorateDestructiveItems(menu, this);
 
         return super.onCreateOptionsMenu(menu);
     }
@@ -385,11 +384,7 @@ public class AlbumDetailActivity extends AbsSlidingMusicPanelActivity implements
     public MaterialCab openCab(int menuRes, @NonNull final MaterialCab.Callback callback) {
         if (cab != null && cab.isActive()) cab.finish();
         adapter.setColor(getPaletteColor());
-        cab = new MaterialCab(this, R.id.cab_stub)
-                .setMenu(menuRes)
-                .setCloseDrawableRes(R.drawable.ic_close_white_24dp)
-                .setBackgroundColor(VinylMusicPlayerColorUtil.shiftBackgroundColorForLightText(getPaletteColor()))
-                .setPopupMenuTheme(PreferenceUtil.getInstance().getGeneralTheme())
+        cab = MenuHelper.setOverflowMenu(this, menuRes, getPaletteColor())
                 .start(new MaterialCab.Callback() {
                     @Override
                     public boolean onCabCreated(MaterialCab materialCab, Menu menu) {
@@ -407,7 +402,7 @@ public class AlbumDetailActivity extends AbsSlidingMusicPanelActivity implements
                     }
                 });
 
-        MenuHelper.setDeleteMenuItemRed(cab.getMenu(), this);
+        MenuHelper.decorateDestructiveItems(cab.getMenu(), this);
 
         return cab;
     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/AlbumDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/AlbumDetailActivity.java
@@ -406,6 +406,9 @@ public class AlbumDetailActivity extends AbsSlidingMusicPanelActivity implements
                         return callback.onCabFinished(materialCab);
                     }
                 });
+
+        MenuHelper.setDeleteMenuItemRed(cab.getMenu(), this);
+
         return cab;
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/ArtistDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/ArtistDetailActivity.java
@@ -56,7 +56,6 @@ import com.poupa.vinylmusicplayer.util.ImageTheme.ThemeStyleUtil;
 import com.poupa.vinylmusicplayer.util.MusicUtil;
 import com.poupa.vinylmusicplayer.util.NavigationUtil;
 import com.poupa.vinylmusicplayer.util.PreferenceUtil;
-import com.poupa.vinylmusicplayer.util.VinylMusicPlayerColorUtil;
 
 import java.util.ArrayList;
 import java.util.Locale;
@@ -405,11 +404,7 @@ public class ArtistDetailActivity extends AbsSlidingMusicPanelActivity implement
     public MaterialCab openCab(int menuRes, @NonNull final MaterialCab.Callback callback) {
         if (cab != null && cab.isActive()) cab.finish();
         songAdapter.setColor(getPaletteColor());
-        cab = new MaterialCab(this, R.id.cab_stub)
-                .setMenu(menuRes)
-                .setCloseDrawableRes(R.drawable.ic_close_white_24dp)
-                .setBackgroundColor(VinylMusicPlayerColorUtil.shiftBackgroundColorForLightText(getPaletteColor()))
-                .setPopupMenuTheme(PreferenceUtil.getInstance().getGeneralTheme())
+        cab = MenuHelper.setOverflowMenu(this, menuRes, getPaletteColor())
                 .start(new MaterialCab.Callback() {
                     @Override
                     public boolean onCabCreated(MaterialCab materialCab, Menu menu) {
@@ -427,7 +422,7 @@ public class ArtistDetailActivity extends AbsSlidingMusicPanelActivity implement
                     }
                 });
 
-        MenuHelper.setDeleteMenuItemRed(cab.getMenu(), this);
+        MenuHelper.decorateDestructiveItems(cab.getMenu(), this);
 
         return cab;
     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/ArtistDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/ArtistDetailActivity.java
@@ -39,6 +39,7 @@ import com.poupa.vinylmusicplayer.glide.GlideApp;
 import com.poupa.vinylmusicplayer.glide.VinylColoredTarget;
 import com.poupa.vinylmusicplayer.glide.VinylGlideExtension;
 import com.poupa.vinylmusicplayer.helper.MusicPlayerRemote;
+import com.poupa.vinylmusicplayer.helper.menu.MenuHelper;
 import com.poupa.vinylmusicplayer.interfaces.CabHolder;
 import com.poupa.vinylmusicplayer.interfaces.LoaderIds;
 import com.poupa.vinylmusicplayer.interfaces.PaletteColorHolder;
@@ -425,6 +426,9 @@ public class ArtistDetailActivity extends AbsSlidingMusicPanelActivity implement
                         return callback.onCabFinished(materialCab);
                     }
                 });
+
+        MenuHelper.setDeleteMenuItemRed(cab.getMenu(), this);
+
         return cab;
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/GenreDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/GenreDetailActivity.java
@@ -32,9 +32,7 @@ import com.poupa.vinylmusicplayer.misc.WrappedAsyncTaskLoader;
 import com.poupa.vinylmusicplayer.model.Genre;
 import com.poupa.vinylmusicplayer.model.Song;
 import com.poupa.vinylmusicplayer.ui.activities.base.AbsSlidingMusicPanelActivity;
-import com.poupa.vinylmusicplayer.util.PreferenceUtil;
 import com.poupa.vinylmusicplayer.util.ViewUtil;
-import com.poupa.vinylmusicplayer.util.VinylMusicPlayerColorUtil;
 import com.simplecityapps.recyclerview_fastscroll.views.FastScrollRecyclerView;
 
 import java.util.ArrayList;
@@ -142,14 +140,10 @@ public class GenreDetailActivity extends AbsSlidingMusicPanelActivity implements
     public MaterialCab openCab(final int menu, final MaterialCab.Callback callback) {
         if (cab != null && cab.isActive()) cab.finish();
         adapter.setColor(ThemeStore.primaryColor(this));
-        cab = new MaterialCab(this, R.id.cab_stub)
-                .setMenu(menu)
-                .setCloseDrawableRes(R.drawable.ic_close_white_24dp)
-                .setBackgroundColor(VinylMusicPlayerColorUtil.shiftBackgroundColorForLightText(ThemeStore.primaryColor(this)))
-                .setPopupMenuTheme(PreferenceUtil.getInstance().getGeneralTheme())
+        cab = MenuHelper.setOverflowMenu(this, menu, ThemeStore.primaryColor(this))
                 .start(callback);
 
-        MenuHelper.setDeleteMenuItemRed(cab.getMenu(), this);
+        MenuHelper.decorateDestructiveItems(cab.getMenu(), this);
 
         return cab;
     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/GenreDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/GenreDetailActivity.java
@@ -24,6 +24,7 @@ import com.poupa.vinylmusicplayer.adapter.song.SongAdapter;
 import com.poupa.vinylmusicplayer.databinding.ActivityGenreDetailBinding;
 import com.poupa.vinylmusicplayer.databinding.SlidingMusicPanelLayoutBinding;
 import com.poupa.vinylmusicplayer.helper.MusicPlayerRemote;
+import com.poupa.vinylmusicplayer.helper.menu.MenuHelper;
 import com.poupa.vinylmusicplayer.interfaces.CabHolder;
 import com.poupa.vinylmusicplayer.interfaces.LoaderIds;
 import com.poupa.vinylmusicplayer.loader.GenreLoader;
@@ -147,6 +148,9 @@ public class GenreDetailActivity extends AbsSlidingMusicPanelActivity implements
                 .setBackgroundColor(VinylMusicPlayerColorUtil.shiftBackgroundColorForLightText(ThemeStore.primaryColor(this)))
                 .setPopupMenuTheme(PreferenceUtil.getInstance().getGeneralTheme())
                 .start(callback);
+
+        MenuHelper.setDeleteMenuItemRed(cab.getMenu(), this);
+
         return cab;
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/PlaylistDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/PlaylistDetailActivity.java
@@ -40,9 +40,7 @@ import com.poupa.vinylmusicplayer.model.Playlist;
 import com.poupa.vinylmusicplayer.model.Song;
 import com.poupa.vinylmusicplayer.ui.activities.base.AbsSlidingMusicPanelActivity;
 import com.poupa.vinylmusicplayer.util.PlaylistsUtil;
-import com.poupa.vinylmusicplayer.util.PreferenceUtil;
 import com.poupa.vinylmusicplayer.util.ViewUtil;
-import com.poupa.vinylmusicplayer.util.VinylMusicPlayerColorUtil;
 import com.simplecityapps.recyclerview_fastscroll.views.FastScrollRecyclerView;
 
 import java.util.ArrayList;
@@ -151,7 +149,7 @@ public class PlaylistDetailActivity extends AbsSlidingMusicPanelActivity impleme
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(playlist instanceof AbsCustomPlaylist ? R.menu.menu_smart_playlist_detail : R.menu.menu_playlist_detail, menu);
-        MenuHelper.setDeleteMenuItemRed(menu, this);
+        MenuHelper.decorateDestructiveItems(menu, this);
         return super.onCreateOptionsMenu(menu);
     }
 
@@ -173,14 +171,10 @@ public class PlaylistDetailActivity extends AbsSlidingMusicPanelActivity impleme
     public MaterialCab openCab(final int menu, final MaterialCab.Callback callback) {
         if (cab != null && cab.isActive()) cab.finish();
         adapter.setColor(ThemeStore.primaryColor(this));
-        cab = new MaterialCab(this, R.id.cab_stub)
-                .setMenu(menu)
-                .setCloseDrawableRes(R.drawable.ic_close_white_24dp)
-                .setBackgroundColor(VinylMusicPlayerColorUtil.shiftBackgroundColorForLightText(ThemeStore.primaryColor(this)))
-                .setPopupMenuTheme(PreferenceUtil.getInstance().getGeneralTheme())
+        cab = MenuHelper.setOverflowMenu(this, menu, ThemeStore.primaryColor(this))
                 .start(callback);
 
-        MenuHelper.setDeleteMenuItemRed(cab.getMenu(), this);
+        MenuHelper.decorateDestructiveItems(cab.getMenu(), this);
 
         return cab;
     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/PlaylistDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/PlaylistDetailActivity.java
@@ -179,6 +179,9 @@ public class PlaylistDetailActivity extends AbsSlidingMusicPanelActivity impleme
                 .setBackgroundColor(VinylMusicPlayerColorUtil.shiftBackgroundColorForLightText(ThemeStore.primaryColor(this)))
                 .setPopupMenuTheme(PreferenceUtil.getInstance().getGeneralTheme())
                 .start(callback);
+
+        MenuHelper.setDeleteMenuItemRed(cab.getMenu(), this);
+
         return cab;
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/folders/FoldersFragment.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/folders/FoldersFragment.java
@@ -37,6 +37,7 @@ import com.poupa.vinylmusicplayer.R;
 import com.poupa.vinylmusicplayer.adapter.SongFileAdapter;
 import com.poupa.vinylmusicplayer.databinding.FragmentFolderBinding;
 import com.poupa.vinylmusicplayer.helper.MusicPlayerRemote;
+import com.poupa.vinylmusicplayer.helper.menu.MenuHelper;
 import com.poupa.vinylmusicplayer.helper.menu.SongMenuHelper;
 import com.poupa.vinylmusicplayer.helper.menu.SongsMenuHelper;
 import com.poupa.vinylmusicplayer.interfaces.CabHolder;
@@ -239,6 +240,9 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
                 .setBackgroundColor(VinylMusicPlayerColorUtil.shiftBackgroundColorForLightText(ThemeStore.primaryColor(getActivity())))
                 .setPopupMenuTheme(PreferenceUtil.getInstance().getGeneralTheme())
                 .start(callback);
+
+        MenuHelper.setDeleteMenuItemRed(cab.getMenu(), this.getContext());
+
         return cab;
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/folders/FoldersFragment.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/folders/FoldersFragment.java
@@ -52,7 +52,6 @@ import com.poupa.vinylmusicplayer.ui.fragments.mainactivity.AbsMainActivityFragm
 import com.poupa.vinylmusicplayer.util.FileUtil;
 import com.poupa.vinylmusicplayer.util.PreferenceUtil;
 import com.poupa.vinylmusicplayer.util.ViewUtil;
-import com.poupa.vinylmusicplayer.util.VinylMusicPlayerColorUtil;
 import com.poupa.vinylmusicplayer.views.BreadCrumbLayout;
 import com.simplecityapps.recyclerview_fastscroll.views.FastScrollRecyclerView;
 
@@ -234,14 +233,10 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
     public MaterialCab openCab(int menuRes, MaterialCab.Callback callback) {
         if (cab != null && cab.isActive()) cab.finish();
         adapter.setColor(ThemeStore.primaryColor(getActivity()));
-        cab = new MaterialCab(getMainActivity(), R.id.cab_stub)
-                .setMenu(menuRes)
-                .setCloseDrawableRes(R.drawable.ic_close_white_24dp)
-                .setBackgroundColor(VinylMusicPlayerColorUtil.shiftBackgroundColorForLightText(ThemeStore.primaryColor(getActivity())))
-                .setPopupMenuTheme(PreferenceUtil.getInstance().getGeneralTheme())
+        cab = MenuHelper.setOverflowMenu(getMainActivity(), menuRes, ThemeStore.primaryColor(getMainActivity()))
                 .start(callback);
 
-        MenuHelper.setDeleteMenuItemRed(cab.getMenu(), this.getContext());
+        MenuHelper.decorateDestructiveItems(cab.getMenu(), this.getContext());
 
         return cab;
     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/library/LibraryFragment.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/library/LibraryFragment.java
@@ -31,6 +31,7 @@ import com.poupa.vinylmusicplayer.databinding.FragmentLibraryBinding;
 import com.poupa.vinylmusicplayer.dialogs.CreatePlaylistDialog;
 import com.poupa.vinylmusicplayer.discog.Discography;
 import com.poupa.vinylmusicplayer.helper.MusicPlayerRemote;
+import com.poupa.vinylmusicplayer.helper.menu.MenuHelper;
 import com.poupa.vinylmusicplayer.interfaces.CabHolder;
 import com.poupa.vinylmusicplayer.model.Album;
 import com.poupa.vinylmusicplayer.model.Artist;
@@ -166,6 +167,9 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
                 .setBackgroundColor(VinylMusicPlayerColorUtil.shiftBackgroundColorForLightText(ThemeStore.primaryColor(getActivity())))
                 .setPopupMenuTheme(PreferenceUtil.getInstance().getGeneralTheme())
                 .start(callback);
+
+        MenuHelper.setDeleteMenuItemRed(cab.getMenu(), this.getContext());
+
         return cab;
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/library/LibraryFragment.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/library/LibraryFragment.java
@@ -50,7 +50,6 @@ import com.poupa.vinylmusicplayer.ui.fragments.mainactivity.library.pager.Playli
 import com.poupa.vinylmusicplayer.ui.fragments.mainactivity.library.pager.SongsFragment;
 import com.poupa.vinylmusicplayer.util.PreferenceUtil;
 import com.poupa.vinylmusicplayer.util.Util;
-import com.poupa.vinylmusicplayer.util.VinylMusicPlayerColorUtil;
 
 public class LibraryFragment extends AbsMainActivityFragment implements CabHolder, MainActivity.MainActivityFragmentCallbacks, ViewPager.OnPageChangeListener, SharedPreferences.OnSharedPreferenceChangeListener {
     Toolbar toolbar;
@@ -161,14 +160,10 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
     @Override
     public MaterialCab openCab(final int menuRes, final MaterialCab.Callback callback) {
         if (cab != null && cab.isActive()) cab.finish();
-        cab = new MaterialCab(getMainActivity(), R.id.cab_stub)
-                .setMenu(menuRes)
-                .setCloseDrawableRes(R.drawable.ic_close_white_24dp)
-                .setBackgroundColor(VinylMusicPlayerColorUtil.shiftBackgroundColorForLightText(ThemeStore.primaryColor(getActivity())))
-                .setPopupMenuTheme(PreferenceUtil.getInstance().getGeneralTheme())
+        cab = MenuHelper.setOverflowMenu(getMainActivity(), menuRes, ThemeStore.primaryColor(getMainActivity()))
                 .start(callback);
 
-        MenuHelper.setDeleteMenuItemRed(cab.getMenu(), this.getContext());
+        MenuHelper.decorateDestructiveItems(cab.getMenu(), this.getContext());
 
         return cab;
     }

--- a/app/src/main/res/menu/menu_cannot_delete_single_songs_playlist_songs_selection.xml
+++ b/app/src/main/res/menu/menu_cannot_delete_single_songs_playlist_songs_selection.xml
@@ -21,15 +21,15 @@
         app:showAsAction="ifRoom" />
 
     <item
-        android:id="@+id/action_delete_from_device"
-        android:icon="@drawable/ic_delete_white_24dp"
-        android:title="@string/action_delete_from_device"
-        app:showAsAction="never" />
-
-    <item
         android:id="@id/action_multi_select_adapter_check_all"
         android:icon="@drawable/ic_select_all_white_24dp"
         android:title="@string/select_all_title"
         app:showAsAction="ifRoom" />
+
+    <item
+        android:id="@+id/action_delete_from_device"
+        android:icon="@drawable/ic_delete_white_24dp"
+        android:title="@string/action_delete_from_device"
+        app:showAsAction="never" />
 
 </menu>

--- a/app/src/main/res/menu/menu_media_selection.xml
+++ b/app/src/main/res/menu/menu_media_selection.xml
@@ -21,15 +21,15 @@
         app:showAsAction="ifRoom" />
 
     <item
-        android:id="@+id/action_delete_from_device"
-        android:icon="@drawable/ic_delete_white_24dp"
-        android:title="@string/action_delete_from_device"
-        app:showAsAction="ifRoom" />
-
-    <item
         android:id="@id/action_multi_select_adapter_check_all"
         android:icon="@drawable/ic_select_all_white_24dp"
         android:title="@string/select_all_title"
+        app:showAsAction="ifRoom" />
+
+    <item
+        android:id="@+id/action_delete_from_device"
+        android:icon="@drawable/ic_delete_white_24dp"
+        android:title="@string/action_delete_from_device"
         app:showAsAction="ifRoom" />
 
 </menu>

--- a/app/src/main/res/menu/menu_playlists_selection.xml
+++ b/app/src/main/res/menu/menu_playlists_selection.xml
@@ -27,15 +27,15 @@
         app:showAsAction="never" />
 
     <item
-        android:id="@+id/action_delete_playlist"
-        android:icon="@drawable/ic_delete_white_24dp"
-        android:title="@string/delete_playlists_title"
-        app:showAsAction="ifRoom" />
-
-    <item
         android:id="@id/action_multi_select_adapter_check_all"
         android:icon="@drawable/ic_select_all_white_24dp"
         android:title="@string/select_all_title"
+        app:showAsAction="ifRoom" />
+
+    <item
+        android:id="@+id/action_delete_playlist"
+        android:icon="@drawable/ic_delete_white_24dp"
+        android:title="@string/delete_playlists_title"
         app:showAsAction="ifRoom" />
 
 </menu>

--- a/app/src/main/res/menu/menu_playlists_songs_selection.xml
+++ b/app/src/main/res/menu/menu_playlists_songs_selection.xml
@@ -26,15 +26,15 @@
         app:showAsAction="ifRoom" />
 
     <item
-        android:id="@+id/action_delete_from_device"
-        android:icon="@drawable/ic_delete_white_24dp"
-        android:title="@string/action_delete_from_device"
-        app:showAsAction="never" />
-
-    <item
         android:id="@id/action_multi_select_adapter_check_all"
         android:icon="@drawable/ic_select_all_white_24dp"
         android:title="@string/select_all_title"
         app:showAsAction="ifRoom" />
+
+    <item
+        android:id="@+id/action_delete_from_device"
+        android:icon="@drawable/ic_delete_white_24dp"
+        android:title="@string/action_delete_from_device"
+        app:showAsAction="never" />
 
 </menu>


### PR DESCRIPTION
As @soncaokim pointed out in https://github.com/AdrienPoupa/VinylMusicPlayer/pull/520 for the multiselection menu (like playlist folder or main activity cab menu) I have forgotten to add the new red accent color, this is now corrected:
![Screenshot_20211011-234002](https://user-images.githubusercontent.com/56130419/136858869-2c00daa9-e0d0-4f87-b103-955770674fe1.png)

