### PR TITLE
Fix crash on restoring queue after song removal

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/discog/Discography.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/discog/Discography.java
@@ -80,13 +80,13 @@ public class Discography implements MusicServiceEventListener {
         }
     }
 
-    public void setStale(boolean value) {
+    void setStale(boolean value) {
         synchronized (cache) {
             cache.isStale = value;
         }
     }
 
-    public boolean isStale() {
+    boolean isStale() {
         synchronized (cache) {
             return cache.isStale;
         }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/discog/Discography.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/discog/Discography.java
@@ -129,23 +129,18 @@ public class Discography implements MusicServiceEventListener {
         ArrayList<Long> orphanSongIds = new ArrayList<>();
         ArrayList<Song> songs = new ArrayList<>();
 
-        while (true) {
-            synchronized (cache) {
-                // Wait for the media store refresh to finish, to ensure correct orphan detection
-                if (!isStale()) {
-                    for (Long id : songIds) {
-                        Song song = cache.songsById.get(id);
-                        if (song != null) {
-                            songs.add(song);
-                        } else if (orphanIdsCleaner != null) {
-                            orphanSongIds.add(id);
-                        }
-                    }
-                    break; // done, exit the loop
+        // If stale, the orphan detection is not correct
+        final boolean stale = isStale();
+
+        synchronized (cache) {
+            for (Long id : songIds) {
+                Song song = cache.songsById.get(id);
+                if (song != null) {
+                    songs.add(song);
+                } else if (!stale && orphanIdsCleaner != null) {
+                    orphanSongIds.add(id);
                 }
             }
-            // Return the CPU time to other
-            Thread.yield();
         }
 
         if (orphanIdsCleaner != null) {

--- a/app/src/main/java/com/poupa/vinylmusicplayer/discog/Discography.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/discog/Discography.java
@@ -130,7 +130,6 @@ public class Discography implements MusicServiceEventListener {
         ArrayList<Song> songs = new ArrayList<>();
 
         // Spinning wait for the media store refresh to finish
-        // TODO Put it under sync block?
         while (isStale()) {Thread.yield();}
 
         synchronized (cache) {

--- a/app/src/main/java/com/poupa/vinylmusicplayer/discog/Discography.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/discog/Discography.java
@@ -86,7 +86,7 @@ public class Discography implements MusicServiceEventListener {
         }
     }
 
-    boolean isStale() {
+    public boolean isStale() {
         synchronized (cache) {
             return cache.isStale;
         }
@@ -129,15 +129,12 @@ public class Discography implements MusicServiceEventListener {
         ArrayList<Long> orphanSongIds = new ArrayList<>();
         ArrayList<Song> songs = new ArrayList<>();
 
-        // If stale, the orphan detection is not correct
-        final boolean stale = isStale();
-
         synchronized (cache) {
             for (Long id : songIds) {
                 Song song = cache.songsById.get(id);
                 if (song != null) {
                     songs.add(song);
-                } else if (!stale && orphanIdsCleaner != null) {
+                } else if (orphanIdsCleaner != null) {
                     orphanSongIds.add(id);
                 }
             }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/discog/MemCache.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/discog/MemCache.java
@@ -23,8 +23,12 @@ import java.util.function.Function;
  */
 
 class MemCache {
-    // Indicate whether the cache can be considered as usable/reliable
-    boolean isStale = true;
+    enum ConsistencyState {
+        RESETTING,
+        REFRESHING,
+        OK
+    };
+    ConsistencyState consistencyState = ConsistencyState.REFRESHING;
 
     final Map<Long, Song> songsById = new HashMap<>();
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/loader/TopAndRecentlyPlayedTracksLoader.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/loader/TopAndRecentlyPlayedTracksLoader.java
@@ -40,7 +40,8 @@ public class TopAndRecentlyPlayedTracksLoader {
 
         HistoryStore historyStore = HistoryStore.getInstance(context);
         ArrayList<Long> songIds = historyStore.getRecentIds(cutoff);
-        return StoreLoader.getSongsFromIdsAndCleanupOrphans(songIds, historyStore::removeSongIds);
+        Discography discography = Discography.getInstance();
+        return discography.getSongsFromIdsAndCleanupOrphans(songIds, historyStore::removeSongIds);
     }
 
     @NonNull
@@ -52,8 +53,9 @@ public class TopAndRecentlyPlayedTracksLoader {
         ArrayList<Long> songIds = new ArrayList<>();
 
         // Collect not played songs
+        Discography discography = Discography.getInstance();
         ArrayList<Long> playedSongIds = historyStore.getRecentIds(0);
-        ArrayList<Song> allSongs = Discography.getInstance().getAllSongs();
+        ArrayList<Song> allSongs = discography.getAllSongs();
         Collections.sort(allSongs, SongSortOrder.BY_DATE_ADDED);
 
         for (Song song : allSongs) {
@@ -66,7 +68,7 @@ public class TopAndRecentlyPlayedTracksLoader {
         ArrayList<Long> notRecentSongIds = historyStore.getRecentIds(-1 * cutoff);
         songIds.addAll(notRecentSongIds);
 
-        return StoreLoader.getSongsFromIdsAndCleanupOrphans(songIds, historyStore::removeSongIds);
+        return discography.getSongsFromIdsAndCleanupOrphans(songIds, historyStore::removeSongIds);
     }
 
     @NonNull
@@ -77,8 +79,8 @@ public class TopAndRecentlyPlayedTracksLoader {
         final int NUMBER_OF_TOP_TRACKS = 100;
         try (Cursor cursor = SongPlayCountStore.getInstance(context).getTopPlayedResults(NUMBER_OF_TOP_TRACKS)){
             ArrayList<Long> songIds = StoreLoader.getIdsFromCursor(cursor, SongPlayCountStore.SongPlayCountColumns.ID);
-
-            return StoreLoader.getSongsFromIdsAndCleanupOrphans(songIds, null);
+            Discography discography = Discography.getInstance();
+            return discography.getSongsFromIdsAndCleanupOrphans(songIds, null);
         }
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/loader/TopAndRecentlyPlayedTracksLoader.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/loader/TopAndRecentlyPlayedTracksLoader.java
@@ -40,17 +40,8 @@ public class TopAndRecentlyPlayedTracksLoader {
 
         HistoryStore historyStore = HistoryStore.getInstance(context);
         ArrayList<Long> songIds = historyStore.getRecentIds(cutoff);
-        Discography discography = Discography.getInstance();
 
-        // Do nothing when the Discography is stale
-        // The stale state means either:
-        // - The cache is being refreshed
-        // - The cache is being reset
-        // In the latter situation, a reset operation takes time, and while the cache is being filled up,
-        // correct and existing songs may be considered as orphan
-        // --> incorrectly cleaned from the auxiliary DBs (history, queue, etc)
-        final boolean isStale = discography.isStale();
-        return discography.getSongsFromIdsAndCleanupOrphans(songIds, isStale ? null : historyStore::removeSongIds);
+        return Discography.getInstance().getSongsFromIdsAndCleanupOrphans(songIds, historyStore::removeSongIds);
     }
 
     @NonNull
@@ -77,15 +68,7 @@ public class TopAndRecentlyPlayedTracksLoader {
         ArrayList<Long> notRecentSongIds = historyStore.getRecentIds(-1 * cutoff);
         songIds.addAll(notRecentSongIds);
 
-        // Do nothing when the Discography is stale
-        // The stale state means either:
-        // - The cache is being refreshed
-        // - The cache is being reset
-        // In the latter situation, a reset operation takes time, and while the cache is being filled up,
-        // correct and existing songs may be considered as orphan
-        // --> incorrectly cleaned from the auxiliary DBs (history, queue, etc)
-        final boolean isStale = discography.isStale();
-        return discography.getSongsFromIdsAndCleanupOrphans(songIds, isStale ? null : historyStore::removeSongIds);
+        return discography.getSongsFromIdsAndCleanupOrphans(songIds, historyStore::removeSongIds);
     }
 
     @NonNull

--- a/app/src/main/java/com/poupa/vinylmusicplayer/loader/TopAndRecentlyPlayedTracksLoader.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/loader/TopAndRecentlyPlayedTracksLoader.java
@@ -41,7 +41,16 @@ public class TopAndRecentlyPlayedTracksLoader {
         HistoryStore historyStore = HistoryStore.getInstance(context);
         ArrayList<Long> songIds = historyStore.getRecentIds(cutoff);
         Discography discography = Discography.getInstance();
-        return discography.getSongsFromIdsAndCleanupOrphans(songIds, historyStore::removeSongIds);
+
+        // Do nothing when the Discography is stale
+        // The stale state means either:
+        // - The cache is being refreshed
+        // - The cache is being reset
+        // In the latter situation, a reset operation takes time, and while the cache is being filled up,
+        // correct and existing songs may be considered as orphan
+        // --> incorrectly cleaned from the auxiliary DBs (history, queue, etc)
+        final boolean isStale = discography.isStale();
+        return discography.getSongsFromIdsAndCleanupOrphans(songIds, isStale ? null : historyStore::removeSongIds);
     }
 
     @NonNull
@@ -68,7 +77,15 @@ public class TopAndRecentlyPlayedTracksLoader {
         ArrayList<Long> notRecentSongIds = historyStore.getRecentIds(-1 * cutoff);
         songIds.addAll(notRecentSongIds);
 
-        return discography.getSongsFromIdsAndCleanupOrphans(songIds, historyStore::removeSongIds);
+        // Do nothing when the Discography is stale
+        // The stale state means either:
+        // - The cache is being refreshed
+        // - The cache is being reset
+        // In the latter situation, a reset operation takes time, and while the cache is being filled up,
+        // correct and existing songs may be considered as orphan
+        // --> incorrectly cleaned from the auxiliary DBs (history, queue, etc)
+        final boolean isStale = discography.isStale();
+        return discography.getSongsFromIdsAndCleanupOrphans(songIds, isStale ? null : historyStore::removeSongIds);
     }
 
     @NonNull

--- a/app/src/main/java/com/poupa/vinylmusicplayer/misc/queue/StaticPlayingQueue.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/misc/queue/StaticPlayingQueue.java
@@ -54,6 +54,14 @@ public class StaticPlayingQueue {
 
         currentPosition = restoredPosition;
 
+        // Adjust for removed songs, marked with Song.EMPTY in the restored queues
+        // See MusicPlaybackQueueStore.getSongPosition
+        for (int i = restoreQueue.size() - 1; i >= 0; --i) {
+            if (restoreQueue.get(i).id == Song.EMPTY_SONG.id) {
+                remove(i);
+            }
+        }
+
         songs = new ArrayList<>();
         songsIsStale = true;
         resetSongs();

--- a/app/src/main/java/com/poupa/vinylmusicplayer/misc/queue/StaticPlayingQueue.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/misc/queue/StaticPlayingQueue.java
@@ -1,6 +1,5 @@
 package com.poupa.vinylmusicplayer.misc.queue;
 
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -8,7 +7,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.poupa.vinylmusicplayer.helper.ShuffleHelper;
 import com.poupa.vinylmusicplayer.model.Song;
-
 
 public class StaticPlayingQueue {
 
@@ -74,6 +72,7 @@ public class StaticPlayingQueue {
             long uniqueId = getNextUniqueId();
             queue.get(i).setUniqueId(uniqueId);
 
+            // TODO The queue sizes may differ
             originalQueue.get(queue.get(i).index).setUniqueId(uniqueId);
         }
     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/misc/queue/StaticPlayingQueue.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/misc/queue/StaticPlayingQueue.java
@@ -72,7 +72,6 @@ public class StaticPlayingQueue {
             long uniqueId = getNextUniqueId();
             queue.get(i).setUniqueId(uniqueId);
 
-            // TODO The queue sizes may differ
             originalQueue.get(queue.get(i).index).setUniqueId(uniqueId);
         }
     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/provider/MusicPlaybackQueueStore.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/provider/MusicPlaybackQueueStore.java
@@ -22,6 +22,7 @@ import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.provider.BaseColumns;
 import android.provider.MediaStore.Audio.AudioColumns;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -221,7 +222,9 @@ public class MusicPlaybackQueueStore extends SQLiteOpenHelper {
                     i++;
                 } while (cursor.moveToNext());
             }
-        } catch (IndexOutOfBoundsException swallowed) {}
+        } catch (IndexOutOfBoundsException swallowed) {
+            Log.e(MusicPlaybackQueueStore.class.getName(), "Error loading queue: " + swallowed.toString());
+        }
 
         return queue;
     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/provider/MusicPlaybackQueueStore.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/provider/MusicPlaybackQueueStore.java
@@ -222,7 +222,7 @@ public class MusicPlaybackQueueStore extends SQLiteOpenHelper {
                 long songId = cursor.getLong(idColumn);
                 int songIndex = cursor.getInt(indexColumn);
 
-                if (removedSongIds.contains(songId)) {
+                if (removedSongIds.contains(songId) || i >= songs.size()) {
                     // Add a place holder song here, to be removed after by the caller
                     // This is done to maintain consistent queue and playing position
                     queue.add(new IndexedSong(Song.EMPTY_SONG, songIndex, IndexedSong.INVALID_INDEX));

--- a/app/src/main/java/com/poupa/vinylmusicplayer/provider/MusicPlaybackQueueStore.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/provider/MusicPlaybackQueueStore.java
@@ -259,6 +259,7 @@ public class MusicPlaybackQueueStore extends SQLiteOpenHelper {
             ArrayList<Long> songIds = StoreLoader.getIdsFromCursor(cursor, BaseColumns._ID);
 
             // Spinning wait for the media store refresh to finish
+            // TODO Rework this fragile wait condition
             while (Discography.getInstance().isStale()) {}
 
             ArrayList<Long> removedSongIds = new ArrayList<>();

--- a/app/src/main/java/com/poupa/vinylmusicplayer/provider/MusicPlaybackQueueStore.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/provider/MusicPlaybackQueueStore.java
@@ -238,8 +238,7 @@ public class MusicPlaybackQueueStore extends SQLiteOpenHelper {
         // Adjust the index value, since there are removed songs
         if (!removedIndexes.isEmpty())
         {
-            Collections.sort(removedIndexes);
-            Collections.reverse(removedIndexes);
+            Collections.sort(removedIndexes, Collections.reverseOrder());
             for (int removedIndex : removedIndexes) {
                 for (IndexedSong song : queue) {
                     if (song.index > removedIndex) {

--- a/app/src/main/java/com/poupa/vinylmusicplayer/provider/MusicPlaybackQueueStore.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/provider/MusicPlaybackQueueStore.java
@@ -258,7 +258,8 @@ public class MusicPlaybackQueueStore extends SQLiteOpenHelper {
             ArrayList<Long> songIds = StoreLoader.getIdsFromCursor(cursor, BaseColumns._ID);
 
             ArrayList<Long> removedSongIds = new ArrayList<>();
-            ArrayList<Song> songs = StoreLoader.getSongsFromIdsAndCleanupOrphans(songIds, removedSongIds::addAll);
+            Discography discography = Discography.getInstance();
+            ArrayList<Song> songs = discography.getSongsFromIdsAndCleanupOrphans(songIds, removedSongIds::addAll);
 
             return getSongPosition(cursor, songs, removedSongIds);
         }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/provider/MusicPlaybackQueueStore.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/provider/MusicPlaybackQueueStore.java
@@ -22,7 +22,6 @@ import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.provider.BaseColumns;
 import android.provider.MediaStore.Audio.AudioColumns;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -212,18 +211,13 @@ public class MusicPlaybackQueueStore extends SQLiteOpenHelper {
     private ArrayList<IndexedSong> getSongPosition(@Nullable Cursor cursor, @NonNull final ArrayList<Song> songs) {
         ArrayList<IndexedSong> queue = new ArrayList<>();
 
-        // TODO It is possible that the size of cursor and songs differ (orphan songs cleaned up)
-        try {
-            if (cursor != null && cursor.moveToFirst()) {
-                int i = 0;
-                int idColumns = cursor.getColumnIndex(MusicPlaybackColumns.INDEX_IN_QUEUE);
-                do {
-                    queue.add(new IndexedSong(songs.get(i), cursor.getInt(idColumns), IndexedSong.INVALID_INDEX));
-                    i++;
-                } while (cursor.moveToNext());
-            }
-        } catch (IndexOutOfBoundsException swallowed) {
-            Log.e(MusicPlaybackQueueStore.class.getName(), "Error loading queue: " + swallowed.toString());
+        if (cursor != null && cursor.moveToFirst()) {
+            int i = 0;
+            int idColumns = cursor.getColumnIndex(MusicPlaybackColumns.INDEX_IN_QUEUE);
+            do {
+                queue.add(new IndexedSong(songs.get(i), cursor.getInt(idColumns), IndexedSong.INVALID_INDEX));
+                i++;
+            } while (cursor.moveToNext());
         }
 
         return queue;
@@ -235,6 +229,7 @@ public class MusicPlaybackQueueStore extends SQLiteOpenHelper {
                 null, null, null, null, null)) {
             ArrayList<Long> songIds = StoreLoader.getIdsFromCursor(cursor, BaseColumns._ID);
 
+            // TODO It is possible that the size of cursor and songs differ (orphan songs cleaned up)
             ArrayList<Song> songs = StoreLoader.getSongsFromIdsAndCleanupOrphans(songIds, null);
 
             return getSongPosition(cursor, songs);

--- a/app/src/main/java/com/poupa/vinylmusicplayer/provider/MusicPlaybackQueueStore.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/provider/MusicPlaybackQueueStore.java
@@ -26,6 +26,7 @@ import android.provider.MediaStore.Audio.AudioColumns;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.poupa.vinylmusicplayer.discog.Discography;
 import com.poupa.vinylmusicplayer.discog.tagging.MultiValuesTagUtil;
 import com.poupa.vinylmusicplayer.misc.queue.IndexedSong;
 import com.poupa.vinylmusicplayer.model.Song;
@@ -256,6 +257,10 @@ public class MusicPlaybackQueueStore extends SQLiteOpenHelper {
         try (Cursor cursor = getReadableDatabase().query(tableName, new String[]{BaseColumns._ID, MusicPlaybackColumns.INDEX_IN_QUEUE},
                 null, null, null, null, null)) {
             ArrayList<Long> songIds = StoreLoader.getIdsFromCursor(cursor, BaseColumns._ID);
+
+            // Spinning wait for the media store refresh to finish
+            while (Discography.getInstance().isStale()) {}
+
             ArrayList<Long> removedSongIds = new ArrayList<>();
             ArrayList<Song> songs = StoreLoader.getSongsFromIdsAndCleanupOrphans(songIds, removedSongIds::addAll);
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/provider/MusicPlaybackQueueStore.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/provider/MusicPlaybackQueueStore.java
@@ -258,10 +258,6 @@ public class MusicPlaybackQueueStore extends SQLiteOpenHelper {
                 null, null, null, null, null)) {
             ArrayList<Long> songIds = StoreLoader.getIdsFromCursor(cursor, BaseColumns._ID);
 
-            // Spinning wait for the media store refresh to finish
-            // TODO Rework this fragile wait condition
-            while (Discography.getInstance().isStale()) {}
-
             ArrayList<Long> removedSongIds = new ArrayList<>();
             ArrayList<Song> songs = StoreLoader.getSongsFromIdsAndCleanupOrphans(songIds, removedSongIds::addAll);
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/provider/MusicPlaybackQueueStore.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/provider/MusicPlaybackQueueStore.java
@@ -211,14 +211,17 @@ public class MusicPlaybackQueueStore extends SQLiteOpenHelper {
     private ArrayList<IndexedSong> getSongPosition(@Nullable Cursor cursor, @NonNull final ArrayList<Song> songs) {
         ArrayList<IndexedSong> queue = new ArrayList<>();
 
-        if (cursor != null && cursor.moveToFirst()) {
-            int i = 0;
-            int idColumns = cursor.getColumnIndex(MusicPlaybackColumns.INDEX_IN_QUEUE);
-            do {
-                queue.add(new IndexedSong(songs.get(i), cursor.getInt(idColumns), IndexedSong.INVALID_INDEX));
-                i++;
-            } while (cursor.moveToNext());
-        }
+        // TODO It is possible that the size of cursor and songs differ (orphan songs cleaned up)
+        try {
+            if (cursor != null && cursor.moveToFirst()) {
+                int i = 0;
+                int idColumns = cursor.getColumnIndex(MusicPlaybackColumns.INDEX_IN_QUEUE);
+                do {
+                    queue.add(new IndexedSong(songs.get(i), cursor.getInt(idColumns), IndexedSong.INVALID_INDEX));
+                    i++;
+                } while (cursor.moveToNext());
+            }
+        } catch (IndexOutOfBoundsException swallowed) {}
 
         return queue;
     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/provider/MusicPlaybackQueueStore.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/provider/MusicPlaybackQueueStore.java
@@ -217,7 +217,7 @@ public class MusicPlaybackQueueStore extends SQLiteOpenHelper {
             int indexColumn = cursor.getColumnIndex(MusicPlaybackColumns.INDEX_IN_QUEUE);
 
             do {
-                int songId = cursor.getInt(idColumn);
+                long songId = cursor.getLong(idColumn);
                 if (removedSongIds.contains(songId)) {
                     // Note that the queue store will still contain the orphan song id
                     // It will only cleaned up when a new queue is created

--- a/app/src/main/java/com/poupa/vinylmusicplayer/provider/StoreLoader.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/provider/StoreLoader.java
@@ -36,11 +36,14 @@ public class StoreLoader {
         ArrayList<Long> orphanSongIds = new ArrayList<>();
 
         ArrayList<Song> songs = new ArrayList<>();
-        final boolean isStale = discography.isStale(); // Must capture this before the discog.getSong
+
+        // Spinning wait for the media store refresh to finish
+        while (discography.isStale()) {}
+
         for (Long id : songIds) {
             Song song = discography.getSong(id);
             if (song.equals(Song.EMPTY_SONG)) {
-                if (!isStale) {orphanSongIds.add(id);}
+                orphanSongIds.add(id);
             } else {
                 songs.add(song);
             }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/provider/StoreLoader.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/provider/StoreLoader.java
@@ -5,11 +5,7 @@ import android.database.Cursor;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.poupa.vinylmusicplayer.discog.Discography;
-import com.poupa.vinylmusicplayer.model.Song;
-
 import java.util.ArrayList;
-import java.util.function.Consumer;
 
 /**
  * @author SC (soncaokim)
@@ -28,30 +24,5 @@ public class StoreLoader {
         }
 
         return ids;
-    }
-
-    @NonNull
-    public static ArrayList<Song> getSongsFromIdsAndCleanupOrphans(@NonNull ArrayList<Long> songIds, @Nullable Consumer<ArrayList<Long>> orphanIdsCleaner) {
-        Discography discography = Discography.getInstance();
-        ArrayList<Long> orphanSongIds = new ArrayList<>();
-
-        ArrayList<Song> songs = new ArrayList<>();
-
-        // Spinning wait for the media store refresh to finish
-        while (discography.isStale()) {}
-
-        for (Long id : songIds) {
-            Song song = discography.getSong(id);
-            if (song.equals(Song.EMPTY_SONG)) {
-                orphanSongIds.add(id);
-            } else {
-                songs.add(song);
-            }
-        }
-
-        if (orphanIdsCleaner != null) {
-            orphanIdsCleaner.accept(orphanSongIds);
-        }
-        return songs;
     }
 }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
@@ -387,26 +387,22 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
 
     public synchronized void restoreQueuesAndPositionIfNecessary() {
         if (!queuesRestored && playingQueue.size()==0) {
-            try {
-                ArrayList<IndexedSong> restoredQueue = MusicPlaybackQueueStore.getInstance(this).getSavedPlayingQueue();
-                ArrayList<IndexedSong> restoredOriginalQueue = MusicPlaybackQueueStore.getInstance(this).getSavedOriginalPlayingQueue();
-                int restoredPosition = PreferenceManager.getDefaultSharedPreferences(this).getInt(SAVED_POSITION, -1);
-                int restoredPositionInTrack = PreferenceManager.getDefaultSharedPreferences(this).getInt(SAVED_POSITION_IN_TRACK, -1);
+            ArrayList<IndexedSong> restoredQueue = MusicPlaybackQueueStore.getInstance(this).getSavedPlayingQueue();
+            ArrayList<IndexedSong> restoredOriginalQueue = MusicPlaybackQueueStore.getInstance(this).getSavedOriginalPlayingQueue();
+            int restoredPosition = PreferenceManager.getDefaultSharedPreferences(this).getInt(SAVED_POSITION, -1);
+            int restoredPositionInTrack = PreferenceManager.getDefaultSharedPreferences(this).getInt(SAVED_POSITION_IN_TRACK, -1);
 
-                if (restoredQueue.size() > 0 && restoredQueue.size() == restoredOriginalQueue.size() && restoredPosition != -1) {
-                    playingQueue = new StaticPlayingQueue(restoredQueue, restoredOriginalQueue, restoredPosition, playingQueue.getShuffleMode());
+            if (restoredQueue.size() > 0 && restoredQueue.size() == restoredOriginalQueue.size() && restoredPosition != -1) {
+                playingQueue = new StaticPlayingQueue(restoredQueue, restoredOriginalQueue, restoredPosition, playingQueue.getShuffleMode());
 
-                    openCurrent();
-                    prepareNext();
+                openCurrent();
+                prepareNext();
 
-                    if (restoredPositionInTrack > 0) seek(restoredPositionInTrack);
+                if (restoredPositionInTrack > 0) seek(restoredPositionInTrack);
 
-                    notHandledMetaChangedForCurrentTrack = true;
-                    sendChangeInternal(META_CHANGED);
-                    sendChangeInternal(QUEUE_CHANGED);
-                }
-            } catch (IndexOutOfBoundsException swallowed) {
-                Log.e(MusicService.class.getName(), "Error restoring queue: " + swallowed.toString());
+                notHandledMetaChangedForCurrentTrack = true;
+                sendChangeInternal(META_CHANGED);
+                sendChangeInternal(QUEUE_CHANGED);
             }
         }
         queuesRestored = true;

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
@@ -394,13 +394,6 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
             if (restoredQueue.size() > 0 && restoredQueue.size() == restoredOriginalQueue.size() && restoredPosition != -1) {
                 playingQueue = new StaticPlayingQueue(restoredQueue, restoredOriginalQueue, restoredPosition, playingQueue.getShuffleMode());
 
-                // Adjust for removed songs, marked with Song.EMPTY in the restored queues
-                for (int i = restoredQueue.size() - 1; i >= 0; --i) {
-                    if (restoredQueue.get(i).id == Song.EMPTY_SONG.id) {
-                        playingQueue.remove(i);
-                    }
-                }
-
                 openCurrent();
                 prepareNext();
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
@@ -67,7 +67,6 @@ import com.poupa.vinylmusicplayer.util.PreferenceUtil;
 import com.poupa.vinylmusicplayer.util.Util;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 
@@ -392,34 +391,15 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
             int restoredPosition = PreferenceManager.getDefaultSharedPreferences(this).getInt(SAVED_POSITION, -1);
             int restoredPositionInTrack = PreferenceManager.getDefaultSharedPreferences(this).getInt(SAVED_POSITION_IN_TRACK, -1);
 
-            // // Adjust for removed songs, marked with IndexedSong.EMPTY_INDEXED_SONG
-            // ArrayList<Integer> removedIndexes = new ArrayList<>();
-            // for (IndexedSong song : restoredQueue) {
-            //     if (song.id == Song.EMPTY_SONG.id) {
-            //         removedIndexes.add(song.index);
-            //     }
-            // }
-            // if (!removedIndexes.isEmpty())
-            // {
-            //     Collections.sort(removedIndexes, Collections.reverseOrder());
-            //     for (int removedIndex : removedIndexes) {
-            //         // Adjust the index value
-            //         for (IndexedSong song : queue) {
-            //             if (song.index > removedIndex) {
-            //                 song.index = song.index - 1;
-            //             }
-            //         }
-            //         // Adjust the queue position
-            //         if (restoredPosition > removedIndex) {
-            //             restoredPosition--;
-            //         } else if (restoredPosition == removedIndex) {
-            //             restoredPositionInTrack = 0; // force to the start of the next track
-            //         }
-            //     }
-            // }
-
             if (restoredQueue.size() > 0 && restoredQueue.size() == restoredOriginalQueue.size() && restoredPosition != -1) {
                 playingQueue = new StaticPlayingQueue(restoredQueue, restoredOriginalQueue, restoredPosition, playingQueue.getShuffleMode());
+
+                // Adjust for removed songs, marked with Song.EMPTY in the restored queues
+                for (int i = restoredQueue.size() - 1; i >= 0; --i) {
+                    if (restoredQueue.get(i).id == Song.EMPTY_SONG.id) {
+                        playingQueue.remove(i);
+                    }
+                }
 
                 openCurrent();
                 prepareNext();

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
@@ -28,7 +28,6 @@ import android.support.v4.media.MediaBrowserCompat;
 import android.support.v4.media.MediaMetadataCompat;
 import android.support.v4.media.session.MediaSessionCompat;
 import android.support.v4.media.session.PlaybackStateCompat;
-import android.util.Log;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
@@ -67,6 +67,7 @@ import com.poupa.vinylmusicplayer.util.PreferenceUtil;
 import com.poupa.vinylmusicplayer.util.Util;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 
@@ -390,6 +391,32 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
             ArrayList<IndexedSong> restoredOriginalQueue = MusicPlaybackQueueStore.getInstance(this).getSavedOriginalPlayingQueue();
             int restoredPosition = PreferenceManager.getDefaultSharedPreferences(this).getInt(SAVED_POSITION, -1);
             int restoredPositionInTrack = PreferenceManager.getDefaultSharedPreferences(this).getInt(SAVED_POSITION_IN_TRACK, -1);
+
+            // // Adjust for removed songs, marked with IndexedSong.EMPTY_INDEXED_SONG
+            // ArrayList<Integer> removedIndexes = new ArrayList<>();
+            // for (IndexedSong song : restoredQueue) {
+            //     if (song.id == Song.EMPTY_SONG.id) {
+            //         removedIndexes.add(song.index);
+            //     }
+            // }
+            // if (!removedIndexes.isEmpty())
+            // {
+            //     Collections.sort(removedIndexes, Collections.reverseOrder());
+            //     for (int removedIndex : removedIndexes) {
+            //         // Adjust the index value
+            //         for (IndexedSong song : queue) {
+            //             if (song.index > removedIndex) {
+            //                 song.index = song.index - 1;
+            //             }
+            //         }
+            //         // Adjust the queue position
+            //         if (restoredPosition > removedIndex) {
+            //             restoredPosition--;
+            //         } else if (restoredPosition == removedIndex) {
+            //             restoredPositionInTrack = 0; // force to the start of the next track
+            //         }
+            //     }
+            // }
 
             if (restoredQueue.size() > 0 && restoredQueue.size() == restoredOriginalQueue.size() && restoredPosition != -1) {
                 playingQueue = new StaticPlayingQueue(restoredQueue, restoredOriginalQueue, restoredPosition, playingQueue.getShuffleMode());

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/player/card/CardPlayerFragment.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/player/card/CardPlayerFragment.java
@@ -178,6 +178,7 @@ public class CardPlayerFragment extends AbsPlayerFragment implements PlayerAlbum
 
     @Override
     public void onMediaStoreChanged() {
+        // TODO If a song is removed from the MediaStore, this is not reflected in the playing queue untill restart
         updateQueue();
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/player/flat/FlatPlayerFragment.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/player/flat/FlatPlayerFragment.java
@@ -172,6 +172,7 @@ public class FlatPlayerFragment extends AbsPlayerFragment implements PlayerAlbum
 
     @Override
     public void onMediaStoreChanged() {
+        // TODO If a song is removed from the MediaStore, this is not reflected in the playing queue untill restart
         updateQueue();
     }
 


### PR DESCRIPTION
To reproduce:
- Start a playing queue with all songs
- Stop the app
- Remove some songs from the device
- Restart the app
