### PR TITLE
Stick to API 29, avoid regression in song deletion

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,12 +3,12 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 29
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 31
+        targetSdkVersion 29
 
-        renderscriptTargetApi 31
+        renderscriptTargetApi 29
         vectorDrawables.useSupportLibrary = true
 
         applicationId 'com.poupa.vinylmusicplayer'
@@ -87,12 +87,12 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.0"
 
     implementation 'androidx.annotation:annotation:1.3.0'
-    implementation 'androidx.appcompat:appcompat:1.4.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.2'
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'androidx.fragment:fragment-ktx:1.4.0'
+    implementation 'androidx.core:core-ktx:1.3.2'
+    implementation 'androidx.fragment:fragment-ktx:1.3.6'
     implementation 'androidx.gridlayout:gridlayout:1.0.0'
-    implementation 'androidx.media:media:1.4.3'
+    implementation 'androidx.media:media:1.3.1'
     implementation 'androidx.palette:palette-ktx:1.0.0'
     implementation 'androidx.percentlayout:percentlayout:1.0.0'
     implementation 'androidx.preference:preference-ktx:1.1.1'


### PR DESCRIPTION
In the long run, this is not a desirable fix.

However it helps avoiding the regression with API 31.