### PR TITLE
Queue restore crash

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
@@ -28,6 +28,7 @@ import android.support.v4.media.MediaBrowserCompat;
 import android.support.v4.media.MediaMetadataCompat;
 import android.support.v4.media.session.MediaSessionCompat;
 import android.support.v4.media.session.PlaybackStateCompat;
+import android.util.Log;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
@@ -392,7 +393,14 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
             int restoredPositionInTrack = PreferenceManager.getDefaultSharedPreferences(this).getInt(SAVED_POSITION_IN_TRACK, -1);
 
             if (restoredQueue.size() > 0 && restoredQueue.size() == restoredOriginalQueue.size() && restoredPosition != -1) {
-                playingQueue = new StaticPlayingQueue(restoredQueue, restoredOriginalQueue, restoredPosition, playingQueue.getShuffleMode());
+                try {
+                    playingQueue = new StaticPlayingQueue(restoredQueue, restoredOriginalQueue, restoredPosition, playingQueue.getShuffleMode());
+                } catch (ArrayIndexOutOfBoundsException queueCopiesOutOfSync) {
+                    // fallback, when the copies of the restored queues are out of sync
+                    // in this case, discard the original queue
+                    Log.e(TAG, "Restored queues are not synchronised", queueCopiesOutOfSync);
+                    playingQueue = new StaticPlayingQueue(restoredQueue, restoredQueue, restoredPosition, playingQueue.getShuffleMode());
+                }
 
                 openCurrent();
                 prepareNext();

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
@@ -398,7 +398,9 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
                 } catch (ArrayIndexOutOfBoundsException queueCopiesOutOfSync) {
                     // fallback, when the copies of the restored queues are out of sync or the queues are corrupted
                     Log.e(TAG, "Restored queues are corrupted", queueCopiesOutOfSync);
+                    final int shuffleMode = playingQueue.getShuffleMode();
                     playingQueue = new StaticPlayingQueue();
+                    playingQueue.setShuffle(shuffleMode);
                 }
 
                 openCurrent();

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
@@ -396,10 +396,9 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
                 try {
                     playingQueue = new StaticPlayingQueue(restoredQueue, restoredOriginalQueue, restoredPosition, playingQueue.getShuffleMode());
                 } catch (ArrayIndexOutOfBoundsException queueCopiesOutOfSync) {
-                    // fallback, when the copies of the restored queues are out of sync
-                    // in this case, discard the original queue
-                    Log.e(TAG, "Restored queues are not synchronised", queueCopiesOutOfSync);
-                    playingQueue = new StaticPlayingQueue(restoredQueue, restoredQueue, restoredPosition, playingQueue.getShuffleMode());
+                    // fallback, when the copies of the restored queues are out of sync or the queues are corrupted
+                    Log.e(TAG, "Restored queues are corrupted", queueCopiesOutOfSync);
+                    playingQueue = new StaticPlayingQueue();
                 }
 
                 openCurrent();


### PR DESCRIPTION
This is an attempt to fix the following crash.
The approach chosen is to ignore the saved queue - i.e. degraded service.
```
java.lang.ArrayIndexOutOfBoundsException: length=1620; index=-1
at java.util.ArrayList.get(ArrayList.java:439)
at com.poupa.vinylmusicplayer.misc.queue.StaticPlayingQueue.restoreUniqueId(Unknown Source:40)
at com.poupa.vinylmusicplayer.misc.queue.StaticPlayingQueue.<init>(Unknown Source:63)
at com.poupa.vinylmusicplayer.service.MusicService.restoreQueuesAndPositionIfNecessary(Unknown Source:99)
at com.poupa.vinylmusicplayer.service.PlaybackHandler.handleMessage(Unknown Source:28)
at android.os.Handler.dispatchMessage(Handler.java:106)
at android.os.Looper.loop(Looper.java:250)
at android.os.HandlerThrbead.run(HandlerThread.java:67)
```

Not reproducible, probably linked to a forced-stop after multiple queue manipulation actions.