### PR TITLE
Upgrade to new CircleCI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/vinyl
     docker:
-      - image: cimg/android:api-29
+      - image: cimg/android:2022.03
     environment:
       JVM_OPTS: -Xmx3200m
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/vinyl
     docker:
-      - image: circleci/android:api-29
+      - image: cimg/android:api-29
     environment:
       JVM_OPTS: -Xmx3200m
     steps:


### PR DESCRIPTION
Fixes the deprecation warning

> You’re using a [deprecated Docker convenience image.](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034) Upgrade to a next-gen Docker convenience image.
