### PR TITLE
Fix Black (OLED) theme to actually be black.

### DIFF
--- a/app/src/main/res/values/styles_parents.xml
+++ b/app/src/main/res/values/styles_parents.xml
@@ -65,7 +65,7 @@
 
     <style name="Theme.VinylMusicPlayer.Base.Black" parent="@style/Theme.VinylMusicPlayer.Base">
         <item name="android:colorBackground">@android:color/black</item>
-		<item name="android:windowBackground">@android:color/black</item>
+        <item name="android:windowBackground">@android:color/black</item>
         <item name="dividerColor">#18FFFFFF</item>
         <item name="defaultFooterColor">@color/md_grey_800</item>
         <item name="cardBackgroundColor">@color/md_black_1000</item>

--- a/app/src/main/res/values/styles_parents.xml
+++ b/app/src/main/res/values/styles_parents.xml
@@ -64,10 +64,11 @@
     </style>
 
     <style name="Theme.VinylMusicPlayer.Base.Black" parent="@style/Theme.VinylMusicPlayer.Base">
-        <item name="android:windowBackground">@android:color/black</item>
+        <item name="android:colorBackground">@android:color/black</item>
+		<item name="android:windowBackground">@android:color/black</item>
         <item name="dividerColor">#18FFFFFF</item>
         <item name="defaultFooterColor">@color/md_grey_800</item>
-        <item name="cardBackgroundColor">@color/md_grey_900</item>
+        <item name="cardBackgroundColor">@color/md_black_1000</item>
         <item name="md_background_color">@color/md_grey_900</item>
 
         <item name="md_delete">@color/delete</item>


### PR DESCRIPTION
The current Black theme's Now Playing view is grey and this has always been the case since time immemorial.

This offers a tried and tested fix I have been using in my own private Phonograph builds for years now, so it would be great to see this finally implemented for more people to enjoy.

Signed-off-by: Sai <saiprasanna@me.com>