### PR TITLE
Add playlist/genre to the search by query intent. Fix a crash on failed search; interpret empty query search as play all songs

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/helper/SearchQueryHelper.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/helper/SearchQueryHelper.java
@@ -1,12 +1,16 @@
 package com.poupa.vinylmusicplayer.helper;
 
 import android.app.SearchManager;
+import android.content.Context;
 import android.os.Bundle;
 import android.provider.MediaStore;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.poupa.vinylmusicplayer.discog.Discography;
+import com.poupa.vinylmusicplayer.loader.GenreLoader;
+import com.poupa.vinylmusicplayer.loader.PlaylistSongLoader;
 import com.poupa.vinylmusicplayer.util.StringUtil;
 import com.poupa.vinylmusicplayer.loader.SongLoader;
 import com.poupa.vinylmusicplayer.model.Song;
@@ -59,5 +63,36 @@ public class SearchQueryHelper {
             }
         }
         return matchingSongs;
+    }
+
+    @NonNull
+    public static ArrayList<Song> getSongs(
+            @NonNull final Context context,
+            @Nullable final String focus,
+            @NonNull final Bundle extras) {
+        // First try known search metrics Genre and Playlist
+        if (focus != null) {
+            if (focus.equals(MediaStore.Audio.Playlists.ENTRY_CONTENT_TYPE)) {
+                // Ignore Android L deprecation by using direct constant as recommended by
+                // https://developer.android.com/guide/components/intents-common
+                final String playlist = extras
+                        .getString("android.intent.extra.playlist");
+                if (playlist != null) {
+                    return PlaylistSongLoader
+                            .getPlaylistSongList(context, playlist);
+                }
+            } else if (focus.equals(MediaStore.Audio.Genres.ENTRY_CONTENT_TYPE)) {
+                // Ignore Android L deprecation by using direct constant as recommended by
+                // https://developer.android.com/guide/components/intents-common
+                final String genre = extras
+                        .getString("android.intent.extra.genre");
+                if (genre != null) {
+                    return GenreLoader
+                            .getGenreSongsByName(genre);
+                }
+            }
+        }
+        // Otherwise do a generic match on all known songs on the phone
+        return getSongs(extras);
     }
 }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/helper/SearchQueryHelper.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/helper/SearchQueryHelper.java
@@ -46,8 +46,14 @@ public class SearchQueryHelper {
         Predicate<Song> isMatchingTitle = (s) -> (!title.isEmpty() && normalize.apply(s.title).contains(title));
         Predicate<Song> isMatchingQuery= (s) -> (!query.isEmpty() && normalize.apply(s.title).contains(query));
 
+        final ArrayList<Song> allSongs = Discography.getInstance().getAllSongs(SongLoader.getSortOrder());
+        // Match empty intent to all songs
+        if(query.isEmpty() && artistName.isEmpty() && albumName.isEmpty() && title.isEmpty()) {
+            return allSongs;
+        }
+
         ArrayList<Song> matchingSongs = new ArrayList<>();
-        for (Song song : Discography.getInstance().getAllSongs(SongLoader.getSortOrder())) {
+        for (Song song : allSongs) {
             if (isMatchingTitle.test(song) || isMatchingAlbum.test(song) || isMatchingArtist.test(song) || isMatchingQuery.test(song)) {
                 matchingSongs.add(song);
             }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/loader/GenreLoader.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/loader/GenreLoader.java
@@ -1,6 +1,7 @@
 package com.poupa.vinylmusicplayer.loader;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.poupa.vinylmusicplayer.discog.Discography;
 import com.poupa.vinylmusicplayer.model.Genre;
@@ -24,4 +25,63 @@ public class GenreLoader {
         if (songs == null) {return new ArrayList<>();}
         return songs;
     }
+
+    /**
+     * Gets all songs contained in the *closestMatch* genre to contain the genreNameSearchTerm.
+     *
+     * Genre name is checked to contain the search term in a case insensitive way.
+     *
+     * Match closeness defined by StringUtil.closestOfMatches
+     *
+     * For instance "Punk" might return songs from the genre named "punk rock", but would prefer
+     * to use a genre named "punk" if it exists.
+     * @param genreNameSearchTerm A partial genre name.
+     * @return song list from the found genre by search term
+     */
+    @NonNull
+    public static ArrayList<Song> getGenreSongsByName(final String genreNameSearchTerm) {
+        final Genre genre = getGenreByName(genreNameSearchTerm);
+        if (genre == null) {
+            return new ArrayList<>();
+        }
+        return getSongs(genre.id);
+    }
+
+    @Nullable
+    private static Genre getGenreByName(final String genreNameSearchTerm) {
+        final String lowercaseSearchTerm = genreNameSearchTerm.toLowerCase();
+        final ArrayList<Genre> genres = getAllGenres();
+        Genre match = null;
+        for(Genre genre : genres) {
+            if (genre.name.toLowerCase().contains(lowercaseSearchTerm)) {
+                if (match == null) {
+                    match = genre;
+                } else {
+                    match = closerMatch(lowercaseSearchTerm, match, genre);
+                }
+            }
+        }
+        return match;
+    }
+
+    /**
+     * This can be sped up by passing in indexOfs and lowerCaseOfs.
+     * Users probably wont complain though, should be fast enough as is.
+     */
+    @NonNull private static Genre closerMatch(
+            @NonNull final String genreNameSearchTerm,
+            @NonNull final Genre first,
+            @NonNull final Genre second) {
+        final StringUtil.ClosestMatch match = StringUtil.closestOfMatches(
+                genreNameSearchTerm,
+                first.name.toLowerCase(),
+                second.name.toLowerCase());
+        // if equal, go with first, respect pre established order.
+        if (match != StringUtil.ClosestMatch.SECOND) {
+            return first;
+        } else {
+            return second;
+        }
+    }
+
 }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/loader/PlaylistLoader.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/loader/PlaylistLoader.java
@@ -69,7 +69,7 @@ public class PlaylistLoader {
     }
 
     @NonNull
-    protected static Playlist getPlaylistFromCursorImpl(@NonNull final Cursor cursor) {
+    private static Playlist getPlaylistFromCursorImpl(@NonNull final Cursor cursor) {
         final long id = cursor.getLong(0);
         final String name = cursor.getString(1);
         return new Playlist(id, name);

--- a/app/src/main/java/com/poupa/vinylmusicplayer/loader/PlaylistLoader.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/loader/PlaylistLoader.java
@@ -69,7 +69,7 @@ public class PlaylistLoader {
     }
 
     @NonNull
-    private static Playlist getPlaylistFromCursorImpl(@NonNull final Cursor cursor) {
+    protected static Playlist getPlaylistFromCursorImpl(@NonNull final Cursor cursor) {
         final long id = cursor.getLong(0);
         final String name = cursor.getString(1);
         return new Playlist(id, name);

--- a/app/src/main/java/com/poupa/vinylmusicplayer/loader/PlaylistSongLoader.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/loader/PlaylistSongLoader.java
@@ -8,8 +8,10 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.poupa.vinylmusicplayer.discog.Discography;
+import com.poupa.vinylmusicplayer.model.Playlist;
 import com.poupa.vinylmusicplayer.model.PlaylistSong;
 import com.poupa.vinylmusicplayer.model.Song;
+import com.poupa.vinylmusicplayer.util.StringUtil;
 
 import java.util.ArrayList;
 
@@ -28,6 +30,23 @@ public class PlaylistSongLoader {
             }
             return songs;
         }
+    }
+
+    @NonNull
+    public static ArrayList<Song> getPlaylistSongList(@NonNull final Context context, @NonNull final String playlistName) {
+        // First find one playlist whose name contains the desired playlist name
+
+        // Avoid SQL injection by using parameter
+        String selection = StringUtil.join(MediaStore.Audio.Playlists.NAME, " LIKE '%' || ? ||'%'");
+        Cursor cursor = PlaylistLoader.makePlaylistCursor(context, selection, new String[]{
+                playlistName// 0
+        });
+        if (cursor.moveToFirst()) {
+            // then get that playlists id, and pass it to the songs by id method
+            Playlist playlist = PlaylistLoader.getPlaylistFromCursorImpl(cursor);
+            return getPlaylistSongList(context, playlist.id);
+        }
+        return new ArrayList<>();
     }
 
     @NonNull

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/MainActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/MainActivity.java
@@ -275,23 +275,9 @@ public class MainActivity extends AbsSlidingMusicPanelActivity {
         boolean handled = false;
 
         if (intent.getAction() != null && intent.getAction().equals(MediaStore.INTENT_ACTION_MEDIA_PLAY_FROM_SEARCH)) {
-            ArrayList<Song> songs = null;
             final String focus = intent.getStringExtra(MediaStore.EXTRA_MEDIA_FOCUS);
-            if (focus != null) {
-                if (focus.equals(MediaStore.Audio.Playlists.ENTRY_CONTENT_TYPE)) {
-                    // ignore Android L deprecation by using direct constant as recommended by
-                    // https://developer.android.com/guide/components/intents-common
-                    final String playlist = intent
-                            .getStringExtra("android.intent.extra.playlist");
-                    if (playlist != null) {
-                        songs = PlaylistSongLoader
-                                .getPlaylistSongList(getApplicationContext(), playlist);
-                    }
-                }
-            }
-            if (songs == null) {
-                songs = SearchQueryHelper.getSongs(intent.getExtras());
-            }
+            final ArrayList<Song> songs =
+                    SearchQueryHelper.getSongs(getApplicationContext(), focus, intent.getExtras());
             // Guards against no songs found. Will cause a crash otherwise
             if (songs.size() > 0) {
                 if (MusicPlayerRemote.getShuffleMode() == MusicService.SHUFFLE_MODE_SHUFFLE) {

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/MainActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/MainActivity.java
@@ -292,12 +292,15 @@ public class MainActivity extends AbsSlidingMusicPanelActivity {
             if (songs == null) {
                 songs = SearchQueryHelper.getSongs(intent.getExtras());
             }
-            if (MusicPlayerRemote.getShuffleMode() == MusicService.SHUFFLE_MODE_SHUFFLE) {
-                MusicPlayerRemote.openAndShuffleQueue(songs, true);
-            } else {
-                MusicPlayerRemote.openQueue(songs, 0, true);
+            // Guards against no songs found. Will cause a crash otherwise
+            if (songs.size() > 0) {
+                if (MusicPlayerRemote.getShuffleMode() == MusicService.SHUFFLE_MODE_SHUFFLE) {
+                    MusicPlayerRemote.openAndShuffleQueue(songs, true);
+                } else {
+                    MusicPlayerRemote.openQueue(songs, 0, true);
+                }
+                handled = true;
             }
-            handled = true;
         }
 
         if (uri != null && uri.toString().length() > 0) {

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/MainActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/MainActivity.java
@@ -275,7 +275,23 @@ public class MainActivity extends AbsSlidingMusicPanelActivity {
         boolean handled = false;
 
         if (intent.getAction() != null && intent.getAction().equals(MediaStore.INTENT_ACTION_MEDIA_PLAY_FROM_SEARCH)) {
-            final ArrayList<Song> songs = SearchQueryHelper.getSongs(intent.getExtras());
+            ArrayList<Song> songs = null;
+            final String focus = intent.getStringExtra(MediaStore.EXTRA_MEDIA_FOCUS);
+            if (focus != null) {
+                if (focus.equals(MediaStore.Audio.Playlists.ENTRY_CONTENT_TYPE)) {
+                    // ignore Android L deprecation by using direct constant as recommended by
+                    // https://developer.android.com/guide/components/intents-common
+                    final String playlist = intent
+                            .getStringExtra("android.intent.extra.playlist");
+                    if (playlist != null) {
+                        songs = PlaylistSongLoader
+                                .getPlaylistSongList(getApplicationContext(), playlist);
+                    }
+                }
+            }
+            if (songs == null) {
+                songs = SearchQueryHelper.getSongs(intent.getExtras());
+            }
             if (MusicPlayerRemote.getShuffleMode() == MusicService.SHUFFLE_MODE_SHUFFLE) {
                 MusicPlayerRemote.openAndShuffleQueue(songs, true);
             } else {

--- a/app/src/main/java/com/poupa/vinylmusicplayer/util/StringUtil.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/util/StringUtil.java
@@ -12,6 +12,11 @@ import java.util.regex.Pattern;
  */
 
 public class StringUtil {
+    public enum ClosestMatch {
+        FIRST,
+        SECOND,
+        EQUAL
+    }
     private static final Collator collator = Collator.getInstance();
     private static final Pattern accentStripRegex = Pattern.compile("\\p{InCombiningDiacriticalMarks}+");
 
@@ -24,6 +29,44 @@ public class StringUtil {
         }
 
         return collator.compare(s1, s2);
+    }
+
+    /**
+     * Returns which string contains a closer match for compareTo.
+     *
+     * Shortest string > string with compareTo closer to front
+     * or equal if neither of those two cases satisfied
+     *
+     * @param compareTo string being searched for
+     * @param first string that contains compareTo
+     * @param second string that contains compareTo
+     * @return ClosestMatch
+     */
+    @NonNull public static ClosestMatch closestOfMatches(
+            @NonNull final String compareTo,
+            @NonNull final String first,
+            @NonNull final String second) {
+        // shortest name is a closer match
+        if (first.length() < second.length()) {
+            return ClosestMatch.FIRST;
+        } else if (second.length() < first.length()) {
+            return ClosestMatch.SECOND;
+        }
+
+        // lengths equal :(
+
+        // name with search term closer to front is a closer match
+        final int indexFirst = first.indexOf(compareTo);
+        final int indexSecond = second.indexOf(compareTo);
+        if (indexFirst < indexSecond) {
+            return ClosestMatch.FIRST;
+        } else if (indexSecond < indexFirst) {
+            return ClosestMatch.SECOND;
+        }
+
+        // indexes equal
+
+        return ClosestMatch.EQUAL;
     }
 
     public static String unicodeNormalize(@NonNull final String text) {

--- a/app/src/main/java/com/poupa/vinylmusicplayer/util/StringUtil.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/util/StringUtil.java
@@ -38,4 +38,13 @@ public class StringUtil {
     public static String stripAccent(@NonNull final String text) {
         return accentStripRegex.matcher(text).replaceAll("");
     }
+
+    @NonNull
+    public static String join(@NonNull String... s) {
+        StringBuilder stringBuilder = new StringBuilder();
+        for (int i = 0; i < s.length; i++) {
+            stringBuilder = stringBuilder.append(s[i]);
+        }
+        return stringBuilder.toString();
+    }
 }


### PR DESCRIPTION
This allows AIs to open playlist by name.
- https://developer.android.com/guide/components/intents-common#PlaySearch

I've been testing using the intents from https://github.com/hobbycommandline/Hobby-Voice-Command-Line but I've been consulting the official google docs and the code I wrote complies with google's standards.