### PR TITLE
Feat: Ignore "the" and "a" prefixes when sorting artists

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/sort/ArtistSortOrder.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/sort/ArtistSortOrder.java
@@ -20,7 +20,7 @@ import java.util.List;
  * @author SC (soncaokim)
  */
 public class ArtistSortOrder {
-    private static final Comparator<Artist> BY_ARTIST = (a1, a2) -> StringUtil.compareIgnoreAccent(a1.name, a2.name);
+    private static final Comparator<Artist> BY_ARTIST = (a1, a2) -> StringUtil.compareIgnoreAccent(Utils.getSectionName(a1.getName()), Utils.getSectionName(a2.getName()));
     private static final Comparator<Artist> BY_DATE_MODIFIED = Comparator.comparingLong(Artist::getDateModified);
 
     private static final List<SortOrder<Artist>> SUPPORTED_ORDERS = Arrays.asList(


### PR DESCRIPTION
Addresses #581 

First of all, thanks to the maintainers of this project ! I have been using Vinyl for the past couple of years or so, and its overall quality helped me change the way I listen to music.

I would like to contribute back to this project which brings me so much.

As described in the open issue, this behavior is quite common in music apps (ex: Sonos, Spotify) and certainly helps listeners of english-named artists to unclutter their "T" letter. 