### PR TITLE
Fix a crash due to #620

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/player/card/CardPlayerFragment.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/player/card/CardPlayerFragment.java
@@ -450,7 +450,11 @@ public class CardPlayerFragment extends AbsPlayerFragment implements PlayerAlbum
                 animatorSet.play(subHeaderAnimator);
             }
 
-            animatorSet.setDuration(ViewUtil.VINYL_MUSIC_PLAYER_ANIM_TIME);
+            // Workaround for a bug https://github.com/AdrienPoupa/VinylMusicPlayer/issues/620
+            for (Animator animator : animatorSet.getChildAnimations()){
+                animator.setDuration(ViewUtil.VINYL_MUSIC_PLAYER_ANIM_TIME);
+            }
+
             return animatorSet;
         }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/player/flat/FlatPlayerFragment.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/player/flat/FlatPlayerFragment.java
@@ -419,7 +419,11 @@ public class FlatPlayerFragment extends AbsPlayerFragment implements PlayerAlbum
                 animatorSet.play(subHeaderAnimator);
             }
 
-            animatorSet.setDuration(ViewUtil.VINYL_MUSIC_PLAYER_ANIM_TIME);
+            // Workaround for a bug https://github.com/AdrienPoupa/VinylMusicPlayer/issues/620
+            for (Animator animator : animatorSet.getChildAnimations()){
+                animator.setDuration(ViewUtil.VINYL_MUSIC_PLAYER_ANIM_TIME);
+            }
+
             return animatorSet;
         }
 


### PR DESCRIPTION
fixes https://github.com/AdrienPoupa/VinylMusicPlayer/issues/620
rationale: https://stackoverflow.com/questions/45419378/disabling-animations-on-a-device-crashes-the-app

I tested manually, and it stopped the crashes I was experiencing